### PR TITLE
Fix comparison of ConstraintWrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY ./target/spanner-ddl-diff-1.0-jar-with-dependencies.jar .
 
 ENTRYPOINT java -jar spanner-ddl-diff-*-jar-with-dependencies.jar \
+      --allowDropStatements \
       --allowRecreateIndexes \
       --allowRecreateConstraints \
       --originalDdlFile ./mount/original.ddl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.8-openjdk-11
+
+WORKDIR /app
+
+COPY ./target/spanner-ddl-diff-1.0-jar-with-dependencies.jar .
+
+ENTRYPOINT java -jar spanner-ddl-diff-*-jar-with-dependencies.jar \
+      --allowRecreateIndexes \
+      --originalDdlFile ./mount/original.ddl \
+      --newDdlFile ./mount/target.ddl \
+      --outputDdlFile ./mount/alter.ddl \
+     --allowRecreateConstraints --allowRecreateIndexes

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY ./target/spanner-ddl-diff-1.0-jar-with-dependencies.jar .
 
 ENTRYPOINT java -jar spanner-ddl-diff-*-jar-with-dependencies.jar \
       --allowRecreateIndexes \
+      --allowRecreateConstraints \
       --originalDdlFile ./mount/original.ddl \
       --newDdlFile ./mount/target.ddl \
       --outputDdlFile ./mount/alter.ddl \
-     --allowRecreateConstraints --allowRecreateIndexes

--- a/TEST.md
+++ b/TEST.md
@@ -1,0 +1,1 @@
+## TESTPLZIGNORE

--- a/apply_diff.sh
+++ b/apply_diff.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SPANNER_INSTANCE="test-spanner-consumer"
+SPANNER_DATABASE="zhiwei-test"
+
+FILE=$1
+gcloud spanner databases ddl update "${SPANNER_DATABASE}" --instance="${SPANNER_INSTANCE}" \
+    --ddl-file=$1

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash 
+mvn clean generate-resources compile assembly:assembly

--- a/gen_diff.sh
+++ b/gen_diff.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Replace placeholders in these variable definitions.
+SPANNER_INSTANCE="test-spanner-consumer"
+SPANNER_DATABASE="zhiwei-test"
+OLD_SCHEMA_FILE=/tmp/original.ddl
+UPDATED_SCHEMA_FILE=$1
+
+# Exit immediately on command failure.
+set -e
+
+# Read schema into a file, removing comments and adding semicolons between the statements.
+gcloud spanner databases ddl describe \
+    --instance="${SPANNER_INSTANCE}" "${SPANNER_DATABASE}" \
+    --format='value(format("{0};"))' > "${OLD_SCHEMA_FILE}"
+
+echo "Output current schema to ${OLD_SCHEMA_FILE}"
+echo "Generating diff to ${UPDATED_SCHEMA_FILE}..."
+
+# Generate ALTER statements.
+# --allowRecreateConstraints doesn't work well
+java -jar target/spanner-ddl-diff-*-jar-with-dependencies.jar \
+      --allowRecreateIndexes \
+      --allowDropStatements \
+      --allowRecreateConstraints \
+      --originalDdlFile "${OLD_SCHEMA_FILE}" \
+      --newDdlFile "${UPDATED_SCHEMA_FILE}" \
+      --outputDdlFile /tmp/alter.ddl
+

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -479,7 +479,10 @@ public class DdlDiff {
       if (statement.jjtGetChild(0) instanceof ASTcreate_table_statement) {
         ASTcreate_table_statement createTable =
             (ASTcreate_table_statement) statement.jjtGetChild(0);
-        tables.put(createTable.getTableName(), createTable);
+        // Remove embedded constraint statements from the CreateTable node
+        // as they are taken into account via `constraints`
+        tables.put(createTable.getTableName(), createTable.clearConstraints());
+
         // convert embedded constraint statements into wrapper object with table name
         // use a single map for all foreign keys, whether created in table or externally
         createTable.getConstraints().values().stream()

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -117,6 +117,14 @@ public class DdlDiff {
       }
       throw new IllegalArgumentException("not a valid constraint type : " + constraint.toString());
     }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other instanceof ConstraintWrapper) {
+        return this.constraint.equals(((ConstraintWrapper) other).constraint);
+      }
+      return false;
+    }
   }
 
   private DdlDiff(

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -286,7 +286,7 @@ public class DdlDiff {
       throw new DdlDiffException("Cannot change primary key of table " + left.getTableName());
     }
 
-    // On delete changed
+    // On delete changed for interleave clause
     if (left.getInterleaveClause().isPresent()
         && !(left.getInterleaveClause()
         .get()
@@ -297,6 +297,38 @@ public class DdlDiff {
               + left.getTableName()
               + " SET "
               + right.getInterleaveClause().get().getOnDelete());
+    }
+
+    // Row Deletion Policy - Modified
+    // TODO add support for ALTER TABLE statements too, deduped like fkey statements.
+    if (left.getRowDeletionPolicyClause().isPresent()
+        && right.getRowDeletionPolicyClause().isPresent()
+        && !(left.getRowDeletionPolicyClause().get()
+             .equals(right.getRowDeletionPolicyClause().get()))) {
+        alterStatements.add(
+                            "ALTER TABLE "
+                            + left.getTableName()
+                            + " REPLACE "
+                            + right.getRowDeletionPolicyClause().get());
+    }
+
+    // Row Deletion Policy - Dropped
+    if (left.getRowDeletionPolicyClause().isPresent()
+        && !right.getRowDeletionPolicyClause().isPresent()) {
+        alterStatements.add(
+                            "ALTER TABLE "
+                            + left.getTableName()
+                            + " DROP ROW DELETION POLICY");
+    }
+
+    // Row Deletion Policy - Added
+    if (!left.getRowDeletionPolicyClause().isPresent()
+        && right.getRowDeletionPolicyClause().isPresent()) {
+        alterStatements.add(
+                            "ALTER TABLE "
+                            + left.getTableName()
+                            + " ADD "
+                            +right.getRowDeletionPolicyClause().get());
     }
 
     // compare columns.

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
@@ -80,6 +80,14 @@ public class ASTcreate_table_statement extends SimpleNode {
     }
   }
 
+    public synchronized Optional<ASTrow_deletion_policy_clause> getRowDeletionPolicyClause() {
+        try {
+            return Optional.of(ASTTreeUtils.getChildByType(children, ASTrow_deletion_policy_clause.class));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
   public ASTcreate_table_statement clearConstraints() {
       this.withConstraints = false;
       return this;
@@ -109,6 +117,12 @@ public class ASTcreate_table_statement extends SimpleNode {
       ret.append(", ");
       ret.append(interleaveClause.get()); // interleave optional
     }
+
+    Optional<ASTrow_deletion_policy_clause> rowDeletionPolicyClause = getRowDeletionPolicyClause();
+    if (rowDeletionPolicyClause.isPresent()) {
+        ret.append(", ");
+        ret.append(rowDeletionPolicyClause.get());
+    }
     return ret.toString();
   }
 
@@ -120,6 +134,7 @@ public class ASTcreate_table_statement extends SimpleNode {
           && !(child instanceof ASTcheck_constraint)
           && !(child instanceof ASTprimary_key)
           && !(child instanceof ASTtable_interleave_clause)
+          && !(child instanceof ASTrow_deletion_policy_clause)
       ) {
         throw new IllegalArgumentException(
             "Unknown child type " + child.getClass().getSimpleName() + " - " + child);

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
@@ -28,6 +28,7 @@ import java.util.Optional;
  * Abstract Syntax Tree parser object for "create_table_statement" token
  */
 public class ASTcreate_table_statement extends SimpleNode {
+  private boolean withConstraints = true;
 
   public ASTcreate_table_statement(int id) {
     super(id);
@@ -67,7 +68,6 @@ public class ASTcreate_table_statement extends SimpleNode {
     return constraints;
   }
 
-
   public synchronized ASTprimary_key getPrimaryKey() {
     return ASTTreeUtils.getChildByType(children, ASTprimary_key.class);
   }
@@ -78,6 +78,11 @@ public class ASTcreate_table_statement extends SimpleNode {
     } catch (IllegalArgumentException e) {
       return Optional.empty();
     }
+  }
+
+  public ASTcreate_table_statement clearConstraints() {
+      this.withConstraints = false;
+      return this;
   }
 
   @Override
@@ -91,7 +96,10 @@ public class ASTcreate_table_statement extends SimpleNode {
     // append column and constraint definitions.
     List<SimpleNode> tableElements = new ArrayList<>();
     tableElements.addAll(getColumns().values());
-    tableElements.addAll(getConstraints().values());
+
+    if (this.withConstraints) {
+        tableElements.addAll(getConstraints().values());
+    }
     ret.append(Joiner.on(", ").join(tableElements));
     ret.append(") ");
     ret.append(getPrimaryKey());

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTforeign_key.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTforeign_key.java
@@ -90,7 +90,7 @@ class ASTforeign_key extends SimpleNode {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof ASTcolumn_def) {
+    if (other instanceof ASTforeign_key) {
       return this.toString().equals(other.toString());
     }
     return false;

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTinterval_expression.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTinterval_expression.java
@@ -1,0 +1,28 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+/** Abstract Syntax Tree parser object for "interval_expression" token */
+public class ASTinterval_expression extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTinterval_expression.class);
+
+    public ASTinterval_expression(int id) {
+        super(id);
+    }
+
+    public ASTinterval_expression(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        // eg INTERVAL num_days DAY
+        // Apparently only supports DAY
+        return "INTERVAL " + children[0] + " DAY";
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_clause.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_clause.java
@@ -1,0 +1,28 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+// TODO Support row deletion policy clause in ALTER statements
+/** Abstract Syntax Tree parser object for "row_deletion_policy_clause" token */
+public class ASTrow_deletion_policy_clause extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_clause.class);
+
+    public ASTrow_deletion_policy_clause(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_clause(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        // eg ROW DELETION POLICY (OLDER_THAN(ExpiredDate, INTERVAL 0 DAY));
+        return String.format("ROW DELETION POLICY (%s)", ((ASTrow_deletion_policy_expression) children[0]));
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_column.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_column.java
@@ -1,0 +1,26 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+/** Abstract Syntax Tree parser object for "row_deletion_policy_column" token */
+public class ASTrow_deletion_policy_column extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_column.class);
+
+    public ASTrow_deletion_policy_column(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_column(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        return jjtGetFirstToken().toString();
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_expression.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_expression.java
@@ -1,0 +1,39 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+// TODO Support row deletion policy clause in ALTER statements
+/** Abstract Syntax Tree parser object for "row_deletion_policy_expression" token */
+public class ASTrow_deletion_policy_expression extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_expression.class);
+
+    public ASTrow_deletion_policy_expression(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_expression(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    private String getRdpFunction() {
+        return ((ASTrow_deletion_policy_function) children[0]).toString();
+    }
+
+    private String getRdpColumn() {
+        return ((ASTrow_deletion_policy_column) children[1]).toString();
+    }
+
+    private String getRdpIntervalExpr() {
+        return ((ASTinterval_expression) children[2]).toString();
+    }
+    @Override
+    public String toString() {
+        // eg OLDER_THAN(ExpiredDate, INTERVAL 0 DAY);
+        return String.format("%s(%s, %s)", getRdpFunction(), getRdpColumn(), getRdpIntervalExpr());
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_function.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTrow_deletion_policy_function.java
@@ -1,0 +1,27 @@
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
+
+/** Abstract Syntax Tree parser object for "row_deletion_policy_function" token */
+public class ASTrow_deletion_policy_function extends SimpleNode {
+    private static final Logger LOG = LoggerFactory.getLogger(ASTrow_deletion_policy_function.class);
+
+    public ASTrow_deletion_policy_function(int id) {
+        super(id);
+    }
+
+    public ASTrow_deletion_policy_function(DdlParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public String toString() {
+        // e.g. OLDER THAN
+        return jjtGetFirstToken().toString();
+    }
+}

--- a/src/main/jjtree-sources/ddl_keywords.jjt
+++ b/src/main/jjtree-sources/ddl_keywords.jjt
@@ -1,18 +1,3 @@
-//
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
 
 TOKEN:
 {
@@ -126,7 +111,9 @@ TOKEN:
   | <CONSTRAINT:               "constraint">
   | <DATABASE:                 "database">
   | <DATE:                     "date">
+  | <DAY:                      "day">
   | <DELETE:                   "delete">
+  | <DELETION:                 "deletion">
   | <DROP:                     "drop">
   | <FLOAT64:                  "float64">
   | <FOREIGN:                  "foreign">
@@ -140,8 +127,11 @@ TOKEN:
   | <NUMERIC:                  "numeric">
   | <OPTIONS:                  "options">
   | <PARENT:                   "parent">
+  | <POLICY:                   "policy">
   | <PRIMARY:                  "primary">
   | <REFERENCES:               "references">
+  | <REPLACE:                  "replace">
+  | <ROW:                      "row">
   | <STORED:                   "stored">
   | <STORING:                  "storing">
   | <STRING:                   "string">
@@ -164,7 +154,9 @@ void pseudoReservedWord() #void :
   | <CONSTRAINT>
   | <DATABASE>
   | <DATE>
+  | <DAY>
   | <DELETE>
+  | <DELETION>
   | <DROP>
   | <FLOAT64>
   | <FOREIGN>
@@ -178,8 +170,11 @@ void pseudoReservedWord() #void :
   | <NUMERIC>
   | <OPTIONS>
   | <PARENT>
+  | <POLICY>
   | <PRIMARY>
   | <REFERENCES>
+  | <REPLACE>
+  | <ROW>
   | <STORED>
   | <STORING>
   | <STRING>

--- a/src/main/jjtree-sources/ddl_parser.jjt
+++ b/src/main/jjtree-sources/ddl_parser.jjt
@@ -100,6 +100,7 @@ void create_table_statement() :
   "(" [ table_element() ( LOOKAHEAD(2) "," table_element() )* [ "," ] ] ")"
   primary_key()
   [ LOOKAHEAD(2) "," table_interleave_clause() ]
+  [ LOOKAHEAD(2) "," row_deletion_policy_clause() ]
 }
 
 void table_element() #void :
@@ -197,6 +198,25 @@ void table_interleave_clause() :
 {
   <INTERLEAVE> <IN> <PARENT> identifier() #interleave_in
     [ on_delete_clause() ]
+}
+
+void row_deletion_policy_clause():
+{}
+{
+  <ROW> <DELETION> <POLICY> "(" row_deletion_policy_expression() ")"
+}
+
+void row_deletion_policy_expression():
+{}
+{
+  identifier() #row_deletion_policy_function
+  "(" identifier() #row_deletion_policy_column "," interval_expression() ")"
+}
+
+void interval_expression():
+{}
+{
+  <INTERVAL> int_value() <DAY>
 }
 
 void on_delete_clause() :
@@ -306,12 +326,16 @@ void alter_table_statement() :
   (   LOOKAHEAD(3) <ADD> #add_column [LOOKAHEAD(2) <COLUMN>] column_def()
     | LOOKAHEAD(3) <DROP> <CONSTRAINT> #drop_constraint
         identifier() #constraint_name
-    | <DROP> #drop_column [LOOKAHEAD(2) <COLUMN>] (identifier() #column_name)
+    | LOOKAHEAD(3) <DROP> <ROW> <DELETION> <POLICY> #drop_row_deletion_policy
+    | LOOKAHEAD(3) <DROP> #drop_column [LOOKAHEAD(2) <COLUMN>] (identifier() #column_name)
+    | LOOKAHEAD(3) <DROP> <ROW> <DELETION> <POLICY> #drop_row_deletion_policy
     | LOOKAHEAD(3) <ALTER> #alter_column [LOOKAHEAD(2) <COLUMN>]
         (identifier() #name) column_def_alter()
     | <SET> #set_on_delete on_delete_clause()
     | LOOKAHEAD(4) <ADD> foreign_key()
-    | <ADD> check_constraint()
+    | LOOKAHEAD(2) <ADD> check_constraint()
+    | LOOKAHEAD(2) <ADD> row_deletion_policy_clause() #add_row_deletion_policy
+    | <REPLACE> row_deletion_policy_clause() #replace_row_deletion_policy
   )
 }
 

--- a/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
@@ -556,7 +556,9 @@ public class DdlDiffTest {
             .isEqualTo(segmentName);
         assertWithMessage("mismatched section names in expectedDdlDiff.txt")
             .that(expectedOutput.getKey()).isEqualTo(segmentName);
-        List<String> expectedDiff = Arrays.asList(expectedOutput.getValue().split("\n"));
+        List<String> expectedDiff = expectedOutput.getValue() != null
+            ? Arrays.asList(expectedOutput.getValue().split("\n"))
+            : Arrays.asList();
 
         DdlDiff ddlDiff = DdlDiff.build(originalSegment.getValue(), newSegment.getValue());
         // Run diff with allowRecreateIndexes and allowDropStatements
@@ -620,7 +622,7 @@ public class DdlDiffTest {
           // new section
           if (sectionName != null) {
             // add closed section.
-            output.put(sectionName, section.toString());
+              output.put(sectionName, section.length() > 0 ? section.toString() : null);
           }
           sectionName = line;
           section = new StringBuilder();
@@ -629,9 +631,6 @@ public class DdlDiffTest {
           throw new IOException("no section name before first statement");
         }
         section.append(line).append('\n');
-      }
-      if (section.length() > 0) {
-        output.put(sectionName, section.toString());
       }
       return output;
     }

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -140,5 +140,8 @@ ALTER TABLE test_gen ADD COLUMN col3 INT64  AS ( col1 * col2 * 2 ) STORED
 
 ALTER TABLE test_gen DROP COLUMN col3
 
+== TEST 23 no modification of foreign key in table
+
+ALTER TABLE test1 DROP COLUMN col2
 ==
 

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -142,6 +142,14 @@ ALTER TABLE test_gen DROP COLUMN col3
 
 == TEST 23 no modification of foreign key in table
 
-ALTER TABLE test1 DROP COLUMN col2
+# No change
+
+== TEST 24 add foreign key via create table
+
+CREATE TABLE test_fkey (col1 INT64, col2 INT64) PRIMARY KEY (col1 ASC)
+ALTER TABLE test_fkey ADD CONSTRAINT fk_col1 FOREIGN KEY (col1) REFERENCES test1 (col1)
+
+== TEST 25 move foreign key out of create table
+# No change
 ==
 

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -151,5 +151,18 @@ ALTER TABLE test_fkey ADD CONSTRAINT fk_col1 FOREIGN KEY (col1) REFERENCES test1
 
 == TEST 25 move foreign key out of create table
 # No change
+
+== TEST 26 create table with row deletion policy
+# No change
+
+
+== TEST 27 drop row deletion policy
+
+ALTER TABLE test_rdp DROP ROW DELETION POLICY
+
+== TEST 28 modify row deletion policy
+
+ALTER TABLE test_rdp REPLACE ROW DELETION POLICY (older_than(created_at, INTERVAL 99 DAY))
+
 ==
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -213,5 +213,13 @@ create table test_gen (
   col2 int64,
 ) primary key (col1);
 
+== TEST 23 no modification of foreign key in table
+
+create table test1 (
+    col1 int64,
+    constraint fk_in_table foreign key (col1) references othertable(othercol1)
+)
+primary key (col1);
+
 ==
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -221,5 +221,22 @@ create table test1 (
 )
 primary key (col1);
 
+== TEST 24 add foreign key via create table
+
+CREATE TABLE test_fkey (
+  col1 INT64,
+  col2 INT64,
+  CONSTRAINT fk_col1 FOREIGN KEY (col1) REFERENCES test1(col1)
+) PRIMARY KEY (col1 ASC)
+
+== TEST 25 move foreign key out of create table
+
+create table test1 (
+    col1 int64,
+    col2 int64 NOT NULL,
+)
+primary key (col1);
+alter table test1 add constraint fk_in_table foreign key (col1) references othertable(othercol1)
+
 ==
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -238,5 +238,29 @@ create table test1 (
 primary key (col1);
 alter table test1 add constraint fk_in_table foreign key (col1) references othertable(othercol1)
 
+== TEST 26 create table with row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
+== TEST 27 drop row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1);
+
+== TEST 28 modify row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 99 DAY));
+
 ==
 

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -224,6 +224,18 @@ create table test_gen (
 
 create table test1 (
     col1 int64,
+    constraint fk_in_table foreign key (col1) references othertable(othercol1)
+)
+primary key (col1);
+
+== TEST 24 add foreign key via create table
+
+-- Nothing here
+
+== TEST 25 move foreign key out of create table
+
+create table test1 (
+    col1 int64,
     col2 int64 NOT NULL,
     constraint fk_in_table foreign key (col1) references othertable(othercol1)
 )

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -241,6 +241,30 @@ create table test1 (
 )
 primary key (col1);
 
+== TEST 26 create table with row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
+== TEST 27 drop row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
+== TEST 28 modify row deletion policy
+
+create table test_rdp (
+  col1 int64,
+  col2 int64,
+  created_at timestamp,
+) primary key (col1), row deletion policy (older_than(created_at, interval 2 DAY));
+
 ==
 
 

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -220,6 +220,15 @@ create table test_gen (
   col3 int64 as ( col1 * col2 * 2) STORED
 ) primary key (col1);
 
+== TEST 23 no modification of foreign key in table
+
+create table test1 (
+    col1 int64,
+    col2 int64 NOT NULL,
+    constraint fk_in_table foreign key (col1) references othertable(othercol1)
+)
+primary key (col1);
+
 ==
 
 


### PR DESCRIPTION
There was no proper `equals` in `ConstraintWrapper`, so foreign keys always generated a diff even if the underlying ddl didn't change. 

Added a new test case for this. I couldn't figure out how to make the `expectedDdlDiff` work with an empty line, so I gave up and made it generate `ALTER TABLE test1 DROP COLUMN col2`. Ideally, we should just check that there is no diff. Feel free to update this PR for a better test case