### PR TITLE
Fix comparison of constraint wrapper so that unchanged foreign keys work correctly

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -117,6 +117,14 @@ public class DdlDiff {
       }
       throw new IllegalArgumentException("not a valid constraint type : " + constraint.toString());
     }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other instanceof ConstraintWrapper) {
+        return this.constraint.equals(((ConstraintWrapper) other).constraint);
+      }
+      return false;
+    }
   }
 
   private DdlDiff(

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -477,7 +477,10 @@ public class DdlDiff {
       if (statement.jjtGetChild(0) instanceof ASTcreate_table_statement) {
         ASTcreate_table_statement createTable =
             (ASTcreate_table_statement) statement.jjtGetChild(0);
-        tables.put(createTable.getTableName(), createTable);
+        // Remove embedded constraint statements from the CreateTable node
+        // as they are taken into account via `constraints`
+        tables.put(createTable.getTableName(), createTable.clearConstraints());
+
         // convert embedded constraint statements into wrapper object with table name
         // use a single map for all foreign keys, whether created in table or externally
         createTable.getConstraints().values().stream()

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 /** Abstract Syntax Tree parser object for "create_table_statement" token */
 public class ASTcreate_table_statement extends SimpleNode {
+  private boolean withConstraints = true;
 
   public ASTcreate_table_statement(int id) {
     super(id);
@@ -77,6 +78,11 @@ public class ASTcreate_table_statement extends SimpleNode {
     }
   }
 
+  public ASTcreate_table_statement clearConstraints() {
+    this.withConstraints = false;
+    return this;
+  }
+
   @Override
   public String toString() {
     verifyTableElements();
@@ -88,7 +94,10 @@ public class ASTcreate_table_statement extends SimpleNode {
     // append column and constraint definitions.
     List<SimpleNode> tableElements = new ArrayList<>();
     tableElements.addAll(getColumns().values());
-    tableElements.addAll(getConstraints().values());
+
+    if (this.withConstraints) {
+      tableElements.addAll(getConstraints().values());
+    }
     ret.append(Joiner.on(", ").join(tableElements));
     ret.append(") ");
     ret.append(getPrimaryKey());

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTforeign_key.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTforeign_key.java
@@ -88,7 +88,7 @@ public class ASTforeign_key extends SimpleNode {
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof ASTcolumn_def) {
+    if (other instanceof ASTforeign_key) {
       return this.toString().equals(other.toString());
     }
     return false;

--- a/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
@@ -187,8 +187,8 @@ public class DdlDiffTest {
     assertThat(
             getTableDiff(
                 "create table test1 (col1 int64) primary key (col1);",
-                "create table test1 (col1 int64, col2 String(MAX), col3 Array<Bytes(100)> not null) "
-                    + "primary key (col1);",
+                "create table test1 (col1 int64, col2 String(MAX), col3 Array<Bytes(100)> not null)"
+                    + " primary key (col1);",
                 true))
         .containsExactly(
             "ALTER TABLE test1 ADD COLUMN col2 STRING(MAX)",
@@ -214,16 +214,16 @@ public class DdlDiffTest {
     // Add multiple rows.
     assertThat(
             getTableDiff(
-                "create table test1 (col1 int64, col2 String(MAX), col3 Array<Bytes(100)> not null) "
-                    + "primary key (col1);",
+                "create table test1 (col1 int64, col2 String(MAX), col3 Array<Bytes(100)> not null)"
+                    + " primary key (col1);",
                 "create table test1 (col1 int64) primary key (col1);",
                 true))
         .containsExactly(
             "ALTER TABLE test1 DROP COLUMN col2", "ALTER TABLE test1 DROP COLUMN col3");
     assertThat(
             getTableDiff(
-                "create table test1 (col1 int64, col2 String(MAX), col3 Array<Bytes(100)> not null) "
-                    + "primary key (col1);",
+                "create table test1 (col1 int64, col2 String(MAX), col3 Array<Bytes(100)> not null)"
+                    + " primary key (col1);",
                 "create table test1 (col1 int64) primary key (col1);",
                 false))
         .isEmpty();
@@ -244,10 +244,10 @@ public class DdlDiffTest {
     // Options added and removed
     assertThat(
             getTableDiff(
-                "create table test1 (col1 timestamp options(allow_commit_timestamp=true), col2 timestamp) "
-                    + "primary key (col1);",
-                "create table test1 (col1 timestamp, col2 timestamp options(allow_commit_timestamp=true)) "
-                    + "primary key (col1);",
+                "create table test1 (col1 timestamp options(allow_commit_timestamp=true), col2"
+                    + " timestamp) primary key (col1);",
+                "create table test1 (col1 timestamp, col2 timestamp"
+                    + " options(allow_commit_timestamp=true)) primary key (col1);",
                 true))
         .containsExactly(
             "ALTER TABLE test1 ALTER COLUMN col1 SET OPTIONS (allow_commit_timestamp=NULL)",
@@ -379,21 +379,25 @@ public class DdlDiffTest {
   public void generateAlterTable_changeGenerationClause() throws DdlDiffException {
     // remove interleave
     getTableDiffCheckDdlDiffException(
-        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1*col2 ) stored) primary key (col1)",
-        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1/col2 ) stored) primary key (col1)",
+        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1*col2 ) stored) primary"
+            + " key (col1)",
+        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1/col2 ) stored) primary"
+            + " key (col1)",
         true,
         "Cannot change generation clause of table test1 column col3 from  AS ");
 
     // add generation
     getTableDiffCheckDdlDiffException(
         "create table test1 (col1 int64, col2 int64, col3 int64) primary key (col1)",
-        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1*col2 ) stored) primary key (col1)",
+        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1*col2 ) stored) primary"
+            + " key (col1)",
         true,
         "Cannot change generation clause of table test1 column col3 from null ");
 
     // remove generation
     getTableDiffCheckDdlDiffException(
-        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1*col2 ) stored) primary key (col1)",
+        "create table test1 (col1 int64, col2 int64, col3 int64 as ( col1*col2 ) stored) primary"
+            + " key (col1)",
         "create table test1 (col1 int64, col2 int64, col3 int64) primary key (col1)",
         true,
         "Cannot change generation clause of table test1 column col3 from  AS");
@@ -581,7 +585,10 @@ public class DdlDiffTest {
         assertWithMessage("mismatched section names in expectedDdlDiff.txt")
             .that(expectedOutput.getKey())
             .isEqualTo(segmentName);
-        List<String> expectedDiff = Arrays.asList(expectedOutput.getValue().split("\n"));
+        List<String> expectedDiff =
+            expectedOutput.getValue() != null
+                ? Arrays.asList(expectedOutput.getValue().split("\n"))
+                : Arrays.asList();
 
         DdlDiff ddlDiff = DdlDiff.build(originalSegment.getValue(), newSegment.getValue());
         // Run diff with allowRecreateIndexes and allowDropStatements
@@ -658,7 +665,7 @@ public class DdlDiffTest {
           // new section
           if (sectionName != null) {
             // add closed section.
-            output.put(sectionName, section.toString());
+            output.put(sectionName, section.length() > 0 ? section.toString() : null);
           }
           sectionName = line;
           section = new StringBuilder();
@@ -667,9 +674,6 @@ public class DdlDiffTest {
           throw new IOException("no section name before first statement");
         }
         section.append(line).append('\n');
-      }
-      if (section.length() > 0) {
-        output.put(sectionName, section.toString());
       }
       return output;
     }

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -140,5 +140,8 @@ ALTER TABLE test_gen ADD COLUMN col3 INT64  AS ( col1 * col2 * 2 ) STORED
 
 ALTER TABLE test_gen DROP COLUMN col3
 
+== TEST 23 no modification of foreign key in table
+
+ALTER TABLE test1 DROP COLUMN col2
 ==
 

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -142,6 +142,14 @@ ALTER TABLE test_gen DROP COLUMN col3
 
 == TEST 23 no modification of foreign key in table
 
-ALTER TABLE test1 DROP COLUMN col2
+# No change
+
+== TEST 24 add foreign key via create table
+
+CREATE TABLE test_fkey (col1 INT64, col2 INT64) PRIMARY KEY (col1 ASC)
+ALTER TABLE test_fkey ADD CONSTRAINT fk_col1 FOREIGN KEY (col1) REFERENCES test1 (col1)
+
+== TEST 25 move foreign key out of create table
+# No change
 ==
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -213,5 +213,13 @@ create table test_gen (
   col2 int64,
 ) primary key (col1);
 
+== TEST 23 no modification of foreign key in table
+
+create table test1 (
+    col1 int64,
+    constraint fk_in_table foreign key (col1) references othertable(othercol1)
+)
+primary key (col1);
+
 ==
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -221,5 +221,22 @@ create table test1 (
 )
 primary key (col1);
 
+== TEST 24 add foreign key via create table
+
+CREATE TABLE test_fkey (
+  col1 INT64,
+  col2 INT64,
+  CONSTRAINT fk_col1 FOREIGN KEY (col1) REFERENCES test1(col1)
+) PRIMARY KEY (col1 ASC)
+
+== TEST 25 move foreign key out of create table
+
+create table test1 (
+    col1 int64,
+    col2 int64 NOT NULL,
+)
+primary key (col1);
+alter table test1 add constraint fk_in_table foreign key (col1) references othertable(othercol1)
+
 ==
 

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -224,6 +224,18 @@ create table test_gen (
 
 create table test1 (
     col1 int64,
+    constraint fk_in_table foreign key (col1) references othertable(othercol1)
+)
+primary key (col1);
+
+== TEST 24 add foreign key via create table
+
+-- Nothing here
+
+== TEST 25 move foreign key out of create table
+
+create table test1 (
+    col1 int64,
     col2 int64 NOT NULL,
     constraint fk_in_table foreign key (col1) references othertable(othercol1)
 )

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -220,6 +220,15 @@ create table test_gen (
   col3 int64 as ( col1 * col2 * 2) STORED
 ) primary key (col1);
 
+== TEST 23 no modification of foreign key in table
+
+create table test1 (
+    col1 int64,
+    col2 int64 NOT NULL,
+    constraint fk_in_table foreign key (col1) references othertable(othercol1)
+)
+primary key (col1);
+
 ==
 
 


### PR DESCRIPTION
Fixes an issue where unchanged FOREIGN KEY constraints are not correctly detected and cause a drop/recreate of the FK in the diff output.

Thanks to @oheyzhiwei for the initial suggestion for the changes in #8 