### PR TITLE
Do not uppercase reserved words in SQL expressions

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcheck_constraint.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcheck_constraint.java
@@ -41,7 +41,7 @@ public class ASTcheck_constraint extends SimpleNode {
     if (children[0] instanceof ASTconstraint_name) {
       child++;
     }
-    return (ASTTreeUtils.tokensToString((ASTcheck_constraint_expression) children[child]));
+    return (ASTTreeUtils.tokensToString((ASTcheck_constraint_expression) children[child], false));
   }
 
   public String toString() {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTexpression.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTexpression.java
@@ -29,6 +29,6 @@ public class ASTexpression extends SimpleNode {
 
   @Override
   public String toString() {
-    return ASTTreeUtils.tokensToString(this);
+    return ASTTreeUtils.tokensToString(this, false);
   }
 }


### PR DESCRIPTION
Do not uppercase reserved word tokens (eg 'key', 'index') in SQL expressions. 

These words can be used for column names, so preserve the case of all SQL expressions

Downside is that other reserved words used in SQL expressions such as `LIKE` will not be uppercased, and so minor differences in case between old and new SQL will show up as differences.