### PR TITLE
Fix change streams options diff 

### DIFF
--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -264,5 +264,19 @@ ALTER CHANGE STREAM toBeChanged SET OPTIONS (retention_period='48h')
 ALTER CHANGE STREAM toBeChangedOnlyTable SET FOR myTable1, myTable2 ( col1 )
 ALTER CHANGE STREAM toBeChangedOnlyOptions SET OPTIONS (retention_period='48h')
 
+== TEST 49 Change stream with changing options
+
+ALTER CHANGE STREAM USER_CHANGES SET OPTIONS (new_option='abc',old_option_to_remove=NULL,option_to_change='789')
+
+== TEST 50 Change stream with adding options
+
+ALTER CHANGE STREAM USER_CHANGES SET OPTIONS (retention_period='7d')
+
+== TEST 51 Change stream with removing options
+
+ALTER CHANGE STREAM USER_CHANGES SET OPTIONS (retention_period=NULL)
+
 ==
+
+
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -437,4 +437,22 @@ create change stream toCreateAll for all;
 create change stream toBeChangedOnlyTable for myTable1, myTable2 ( col1) options (retention_period = '36h');
 create change stream toBeChangedOnlyOptions for myTable1, myTable2 ( col1, col3) options (retention_period = '48h');
 
+== TEST 49 Change stream with changing options
+
+CREATE CHANGE STREAM USER_CHANGES
+  FOR USER OPTIONS (
+  option_to_change='789',
+  new_option='abc'
+);
+
+== TEST 50 Change stream with adding options
+
+CREATE CHANGE STREAM USER_CHANGES
+  FOR USER OPTIONS (retention_period='7d');
+
+== TEST 51 Change stream with removing options
+
+CREATE CHANGE STREAM USER_CHANGES
+  FOR USER;
+
 ==

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -435,6 +435,24 @@ create change stream toBeChanged for myTable1, myTable2 ( col1, col3) options (r
 create change stream toBeChangedOnlyTable for myTable1, myTable2 ( col1, col3) options (retention_period = '36h');
 create change stream toBeChangedOnlyOptions for myTable1, myTable2 ( col1, col3) options (retention_period = '36h');
 
+== TEST 49 Change stream with changing options
+
+CREATE CHANGE STREAM USER_CHANGES
+  FOR USER OPTIONS (
+  old_option_to_remove = '123',
+  option_to_change='456'
+);
+
+== TEST 50 Change stream with adding options
+
+CREATE CHANGE STREAM USER_CHANGES
+  FOR USER;
+
+== TEST 51 Change stream with removing options
+
+CREATE CHANGE STREAM USER_CHANGES
+  FOR USER  OPTIONS (retention_period='7d');
+
 ==
 
 


### PR DESCRIPTION
Correctly handle differing OPTIONS clauses in change streams, and does not NPE when one or other statement does not have an OPTIONS clause.

Fixes #80 