### PR TITLE
feat: Add handling for updating stored columns on indexes

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTstored_column_list.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTstored_column_list.java
@@ -18,6 +18,7 @@ package com.google.cloud.solutions.spannerddl.parser;
 
 import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
 import com.google.common.base.Joiner;
+import java.util.List;
 
 public class ASTstored_column_list extends SimpleNode {
 
@@ -31,8 +32,10 @@ public class ASTstored_column_list extends SimpleNode {
 
   @Override
   public String toString() {
-    return "STORING ( "
-        + Joiner.on(", ").join(AstTreeUtils.getChildrenAssertType(children, ASTstored_column.class))
-        + " )";
+    return "STORING ( " + Joiner.on(", ").join(getStoredColumns()) + " )";
+  }
+
+  public List<ASTstored_column> getStoredColumns() {
+    return AstTreeUtils.getChildrenAssertType(children, ASTstored_column.class);
   }
 }

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -250,7 +250,7 @@ ALTER TABLE test1 ADD CONSTRAINT fk_in_table FOREIGN KEY ( col2 ) REFERENCES oth
 == TEST 47 Modifying index with IF NOT EXIST
 
 DROP INDEX test4
-CREATE INDEX test4 ON test1 ( col1 ASC ) STORING ( col2 )
+CREATE UNIQUE NULL_FILTERED INDEX test4 ON test1 ( col1 ASC ) STORING ( col2 )
 
 == TEST 48 change streams create modify delete in correct order wrt tables
 
@@ -276,7 +276,22 @@ ALTER CHANGE STREAM USER_CHANGES SET OPTIONS (retention_period='7d')
 
 ALTER CHANGE STREAM USER_CHANGES SET OPTIONS (retention_period=NULL)
 
+== TEST 52 Modifying index STORING clause only - add
+
+ALTER INDEX test4 ADD STORED COLUMN col4
+ALTER INDEX test5 ADD STORED COLUMN col2
+
+== TEST 53 Modifying index STORING clause only - remove
+
+ALTER INDEX test4 DROP STORED COLUMN col3
+ALTER INDEX test5 DROP STORED COLUMN col2
+ALTER INDEX test5 DROP STORED COLUMN col3
+
+== TEST 54 Modifying index STORING clause only - add/remove
+
+ALTER INDEX test4 DROP STORED COLUMN col2
+ALTER INDEX test4 ADD STORED COLUMN col4
+ALTER INDEX test4 ADD STORED COLUMN col5
+
 ==
-
-
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -425,7 +425,7 @@ primary key (col1);
 
 == TEST 47 Modifying index with IF NOT EXIST
 
-Create index IF NOT EXISTS test4 on test1 ( col1 ) STORING ( col2 )
+Create UNIQUE NULL_filtered index IF NOT EXISTS test4 on test1 ( col1 ) STORING ( col2 )
 
 == TEST 48 change streams create modify delete in correct order wrt tables
 
@@ -454,5 +454,19 @@ CREATE CHANGE STREAM USER_CHANGES
 
 CREATE CHANGE STREAM USER_CHANGES
   FOR USER;
+
+== TEST 52 Modifying index STORING clause only - add
+
+CREATE UNIQUE NULL_FILTERED INDEX test4 ON test1 ( col1 ASC ) STORING ( col2, col3, col4 );
+CREATE UNIQUE NULL_FILTERED INDEX test5 ON test1 ( col1 ASC ) STORING ( col2 );
+
+== TEST 53 Modifying index STORING clause only - remove
+
+CREATE UNIQUE NULL_FILTERED INDEX test4 ON test1 ( col1 ASC ) STORING ( col2 );
+CREATE UNIQUE NULL_FILTERED INDEX test5 ON test1 ( col1 ASC );
+
+== TEST 54 Modifying index STORING clause only - add/remove
+
+CREATE UNIQUE NULL_FILTERED INDEX test4 ON test1 ( col1 ASC ) STORING ( col3, col5, col4 );
 
 ==

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -424,7 +424,7 @@ primary key (col1);
 
 == TEST 47 Modifying index with IF NOT EXIST
 
-Create index IF NOT EXISTS test4 on test1 ( col1 )
+Create index IF NOT EXISTS test4 on test1 ( col1 )  STORING ( col2 )
 
 == TEST 48 change streams create modify delete in correct order wrt tables
 
@@ -452,6 +452,20 @@ CREATE CHANGE STREAM USER_CHANGES
 
 CREATE CHANGE STREAM USER_CHANGES
   FOR USER  OPTIONS (retention_period='7d');
+
+== TEST 52 Modifying index STORING clause only - add
+
+CREATE UNIQUE NULL_FILTERED INDEX test4 ON test1 ( col1 ASC ) STORING ( col2, col3 );
+CREATE UNIQUE NULL_FILTERED INDEX test5 ON test1 ( col1 ASC );
+
+== TEST 53 Modifying index STORING clause only - remove
+
+CREATE UNIQUE NULL_FILTERED INDEX test4 ON test1 ( col1 ASC ) STORING ( col2, col3 );
+CREATE UNIQUE NULL_FILTERED INDEX test5 ON test1 ( col1 ASC ) STORING ( col2, col3 );
+
+== TEST 54 Modifying index STORING clause only - add/remove
+
+CREATE UNIQUE NULL_FILTERED INDEX test4 ON test1 ( col1 ASC ) STORING ( col2, col3 );
 
 ==
 


### PR DESCRIPTION
Fixes #82

Allows stored columns to be added/removed from an index without recreating it.