### PR TITLE
Upgrade to fixed version of errorprone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <exec-maven.version>3.3.0</exec-maven.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <auto-value.version>1.11.0</auto-value.version>
-    <error-prone.version>2.29.1</error-prone.version>
+    <error-prone.version>2.29.2</error-prone.version>
     <maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
   </properties>


### PR DESCRIPTION
Error Prone v2.29.1 has a bug that causes a compilation failure with Maven. v2.29.2 fixes that bug. See details here: https://github.com/google/error-prone/releases/tag/v2.29.2 