### PR TITLE
allow DdlDiff to be invoked as a library instead of command line

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -631,7 +631,7 @@ public class DdlDiff {
     }
   }
 
-  static DdlDiff build(String originalDdl, String newDdl) throws DdlDiffException {
+  public static DdlDiff build(String originalDdl, String newDdl) throws DdlDiffException {
     List<ASTddl_statement> originalStatements;
     List<ASTddl_statement> newStatements;
     try {
@@ -775,18 +775,18 @@ public class DdlDiff {
   /**
    * Main entrypoint for this tool.
    *
-   * @see DdlDiffOptions.java for command line options.
+   * @see DdlDiffOptions for command line options.
    */
   public static void main(String[] args) {
-
     DdlDiffOptions options = DdlDiffOptions.parseCommandLine(args);
-    ;
+
     try {
-      List<String> alterStatements =
+      DdlDiff ddlDiff =
           DdlDiff.build(
-                  new String(Files.readAllBytes(options.originalDdlPath()), UTF_8),
-                  new String(Files.readAllBytes(options.newDdlPath()), UTF_8))
-              .generateDifferenceStatements(options.args());
+              new String(Files.readAllBytes(options.originalDdlPath()), UTF_8),
+              new String(Files.readAllBytes(options.newDdlPath()), UTF_8));
+
+      List<String> alterStatements = ddlDiff.generateDifferenceStatements(options.args());
 
       StringBuilder output = new StringBuilder();
       for (String statement : alterStatements) {


### PR DESCRIPTION
We are writing a service where during CI and CD phases the DDL diff will be invoked. So we need a programatic way of invoking the diff functionality from calling service where DDL files can be passed as strings instead of temporarily creating files on build system and invoking the JAR via command line.
