### PR TITLE
fix: null options for equivalent change streams

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -379,12 +379,14 @@ public class DdlDiff {
 
         String optionsDiff = generateOptionsUpdates(Maps.difference(oldOptionsKv, newOptionsKv));
 
+        if (optionsDiff != null) {
         output.add(
             "ALTER CHANGE STREAM "
                 + changedChangeStream.rightValue().getName()
                 + " SET OPTIONS ("
                 + optionsDiff
                 + ")");
+        }
       }
     }
 

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -431,6 +431,11 @@ Create UNIQUE NULL_filtered index IF NOT EXISTS test4 on test1 ( col1 ) STORING 
 
 Create table myCreatedTable (mycol int64) primary key (mycol);
 create change stream toremain for all options (retention_period = '36h');
+create change stream toremain2 for all
+OPTIONS (
+value_capture_type = 'OLD_AND_NEW_VALUES',
+retention_period = '7d',
+exclude_ttl_deletes = true);
 create change stream toBeChanged for myTable2 ( col1, col3, col4), mytable3 () options (retention_period = '48h');
 create change stream toCreate for mytable4 options (retention_period = '36h');
 create change stream toCreateAll for all;

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -430,6 +430,11 @@ Create index IF NOT EXISTS test4 on test1 ( col1 )  STORING ( col2 )
 
 Create table myToBeDeletedTable (mycol int64) primary key (mycol);
 create change stream toremain for all options (retention_period = '36h');
+create change stream toremain2 for all
+OPTIONS (
+retention_period = '7d',
+value_capture_type = 'OLD_AND_NEW_VALUES',
+exclude_ttl_deletes = true);
 create change stream toBeDeleted for myTable options (retention_period = '36h');
 create change stream toBeChanged for myTable1, myTable2 ( col1, col3) options (retention_period = '36h');
 create change stream toBeChangedOnlyTable for myTable1, myTable2 ( col1, col3) options (retention_period = '36h');


### PR DESCRIPTION
Fix this issue (https://github.com/cloudspannerecosystem/spanner-schema-diff-tool/issues/156)