### PR TITLE
feat: make Spanner SQL DDL parsing public

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/AstTreeUtils.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/AstTreeUtils.java
@@ -20,6 +20,7 @@ import com.google.cloud.solutions.spannerddl.parser.DdlParserConstants;
 import com.google.cloud.solutions.spannerddl.parser.Node;
 import com.google.cloud.solutions.spannerddl.parser.SimpleNode;
 import com.google.cloud.solutions.spannerddl.parser.Token;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -31,6 +32,17 @@ import java.util.stream.StreamSupport;
 public class AstTreeUtils {
 
   /** Gets (and casts) the first found child of a specific node type. */
+  public static <T> T getOptionalChildByType(Node node, Class<T> type) {
+    for (int i = 0, count = node.jjtGetNumChildren(); i < count; i++) {
+      Node child = node.jjtGetChild(i);
+      if (type.isInstance(child)) {
+        return type.cast(child);
+      }
+    }
+    return null;
+  }
+
+  /** Gets (and casts) the first found child of a specific node type. */
   public static <T> T getOptionalChildByType(Node[] children, Class<T> type) {
     for (Node child : children) {
       if (type.isInstance(child)) {
@@ -38,6 +50,18 @@ public class AstTreeUtils {
       }
     }
     return null;
+  }
+
+  /**
+   * Gets (and casts) the first found child of a specific node type, throwing an exception if it
+   * does not exist.
+   */
+  public static <T> T getChildByType(Node node, Class<T> type) {
+    T child = getOptionalChildByType(node, type);
+    if (child == null) {
+      throw new IllegalArgumentException("Cannot find child of type " + type.getName());
+    }
+    return child;
   }
 
   /**
@@ -62,6 +86,19 @@ public class AstTreeUtils {
   /** Checks if the word is a reserved word/known token. */
   public static boolean isReservedWord(String word) {
     return reservedWords.contains(word);
+  }
+
+  /**
+   * Ensures that the passed Node children are of a specific node type, and returns a List with the
+   * specific type.
+   */
+  public static <T> List<T> getChildrenAssertType(Node node, Class<T> type) {
+    List<T> list = new ArrayList<>();
+    for (int i = 0, count = node.jjtGetNumChildren(); i < count; i++) {
+      Node child = node.jjtGetChild(i);
+      list.add(type.cast(child));
+    }
+    return list;
   }
 
   /**

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DatabaseDefinition.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DatabaseDefinition.java
@@ -46,7 +46,13 @@ import java.util.Optional;
  */
 @AutoValue
 public abstract class DatabaseDefinition {
-  static DatabaseDefinition create(List<ASTddl_statement> statements) {
+  /**
+   * Create a database definition from the list of parsed DDL statements.
+   *
+   * @param statements List of parsed DDL statements
+   * @return DatabaseDefinition instance
+   */
+  public static DatabaseDefinition create(List<ASTddl_statement> statements) {
     // Use LinkedHashMap to preserve creation order in original DDL.
     LinkedHashMap<String, ASTcreate_table_statement> tablesInCreationOrder = new LinkedHashMap<>();
     LinkedHashMap<String, ASTcreate_index_statement> indexes = new LinkedHashMap<>();

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -699,8 +699,14 @@ public class DdlDiff {
     }
   }
 
-  @VisibleForTesting
-  static List<ASTddl_statement> parseDdl(String original) throws DdlDiffException {
+  /**
+   * Parses the Cloud Spanner Schema (DDL) string to a list of AST DDL statements.
+   *
+   * @param original DDL to parse
+   * @return List of parsed DDL statements
+   * @throws DdlDiffException if there is an error in parsing the DDL
+   */
+  public static List<ASTddl_statement> parseDdl(String original) throws DdlDiffException {
     // Remove "--" comments and split by ";"
     List<String> statements = Splitter.on(';').splitToList(original.replaceAll("--.*(\n|$)", ""));
     ArrayList<ASTddl_statement> ddlStatements = new ArrayList<>(statements.size());


### PR DESCRIPTION
The Spanner SQL statements are specific to Spanner database. The DDLDiff that parses the DDL statement and converts to in-memory AST tree is valuable to be used outside of the diff generation.

Other Java programs can use the parsed information for other usages like CI testing on the structure of the schema