### PR TITLE
feat: support annotations in SQL file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
                   src/main/jjtree-sources/ddl_keywords.jjt \
                   src/main/jjtree-sources/ddl_string_bytes_tokens.jjt \
                   src/main/jjtree-sources/ddl_expression.jjt \
+                  src/main/jjtree-sources/ddl_annotation.jjt \
                   src/main/jjtree-sources/ddl_parser.jjt \
                   &gt; ${project.build.directory}/generated-sources/jjtree-src/DdlParser.jjt</argument>
               </arguments>

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -707,6 +707,11 @@ public class DdlDiff {
    * @throws DdlDiffException if there is an error in parsing the DDL
    */
   public static List<ASTddl_statement> parseDdl(String original) throws DdlDiffException {
+    // the annotations are prefixed with "--" so that SQL file remains valid.
+    // strip the comment prefix before so that annotations can be parsed.
+    // otherwise they will be ignored as comment lines
+    original = original.replaceAll("-- *@", "@");
+
     // Remove "--" comments and split by ";"
     List<String> statements = Splitter.on(';').splitToList(original.replaceAll("--.*(\n|$)", ""));
     ArrayList<ASTddl_statement> ddlStatements = new ArrayList<>(statements.size());

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -716,7 +716,7 @@ public class DdlDiff {
    *
    * @param original DDL to parse
    * @param parseAnnotationInComments If true then the annotations that appear as comments
-   *     "-- @ANNOTATION <annotation>" will be parsed
+   *     "-- @ANNOTATION annotation" will be parsed
    * @return List of parsed DDL statements
    */
   public static List<ASTddl_statement> parseDdl(String original, boolean parseAnnotationInComments)

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -707,10 +708,26 @@ public class DdlDiff {
    * @throws DdlDiffException if there is an error in parsing the DDL
    */
   public static List<ASTddl_statement> parseDdl(String original) throws DdlDiffException {
+    return parseDdl(original, false);
+  }
+
+  /**
+   * Parses the Cloud Spanner Schema (DDL) string to a list of AST DDL statements.
+   *
+   * @param original DDL to parse
+   * @param parseAnnotationInComments If true then the annotations that appear as comments
+   *     "-- @ANNOTATION <annotation>" will be parsed
+   * @return List of parsed DDL statements
+   */
+  public static List<ASTddl_statement> parseDdl(String original, boolean parseAnnotationInComments)
+      throws DdlDiffException {
     // the annotations are prefixed with "--" so that SQL file remains valid.
     // strip the comment prefix before so that annotations can be parsed.
     // otherwise they will be ignored as comment lines
-    original = original.replaceAll("-- *@", "@");
+    if (parseAnnotationInComments) {
+      original =
+          Pattern.compile("^\\s*--\\s+@", Pattern.MULTILINE).matcher(original).replaceAll("@");
+    }
 
     // Remove "--" comments and split by ";"
     List<String> statements = Splitter.on(';').splitToList(original.replaceAll("--.*(\n|$)", ""));

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,29 @@ import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Abstract Syntax Tree parser object for "annotation" token */
+/**
+ * Abstract Syntax Tree parser object for "annotation" token
+ *
+ * <p>Column Annotations are NOT a feature of Cloud Spanner.
+ *
+ * <p>This is an additional feature of the Cloud Spanner Schema parser exclusively in this tool so
+ * that users of this tool can add metadata to colums, and have that metadata represented in the
+ * parsed schema.
+ *
+ * <p>To use Annotations, they should be added to a CREATE TABLE statement as follows:
+ *
+ * <pre>
+ *  CREATE TABLE Albums (
+ *   -- @ANNOTATION SOMETEXT,
+ *    id STRING(36),
+ *  ) PRIMARY KEY (id)
+ * </pre>
+ *
+ * Annotations need to be on their own line, and terminate with a comma. (This is because the '-- '
+ * prefix is removed before using the JJT parser).
+ *
+ * <p>As they are comments, they are ignored by the diff generator and by Spanner itself.
+ */
 public class ASTannotation extends SimpleNode {
   public ASTannotation(int id) {
     super(id);

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import static com.google.cloud.solutions.spannerddl.diff.AstTreeUtils.getChildByType;
+
+import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Abstract Syntax Tree parser object for "annotation" token */
+public class ASTannotation extends SimpleNode {
+  public ASTannotation(int id) {
+    super(id);
+  }
+
+  public ASTannotation(DdlParser p, int id) {
+    super(p, id);
+  }
+
+  public String getName() {
+    return AstTreeUtils.tokensToString(getChildByType(children, ASTname.class));
+  }
+
+  public List<ASTannotation_param> getParams() {
+    List<ASTannotation_param> params = new ArrayList<>();
+    for (Node child : children) {
+      if (child instanceof ASTannotation_param) {
+        params.add((ASTannotation_param) child);
+      }
+    }
+    return params;
+  }
+
+  public String getAnnotation() {
+    return AstTreeUtils.tokensToString(this, false).replaceAll(" ", "");
+  }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation_param.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation_param.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation_param.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTannotation_param.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.spannerddl.parser;
+
+import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
+
+public class ASTannotation_param extends SimpleNode {
+  public ASTannotation_param(int id) {
+    super(id);
+  }
+
+  public ASTannotation_param(DdlParser p, int id) {
+    super(p, id);
+  }
+
+  public String getKey() {
+    ASTparam_key key = AstTreeUtils.getChildByType(this, ASTparam_key.class);
+    return AstTreeUtils.tokensToString(key);
+  }
+
+  public String getValue() {
+    ASTparam_val val = AstTreeUtils.getOptionalChildByType(this, ASTparam_val.class);
+    if (val != null) {
+      return AstTreeUtils.tokensToString(val);
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
@@ -140,7 +140,8 @@ public class ASTcreate_table_statement extends SimpleNode {
             ASTcheck_constraint.class,
             ASTprimary_key.class,
             ASTtable_interleave_clause.class,
-            ASTrow_deletion_policy_clause.class));
+            ASTrow_deletion_policy_clause.class,
+            ASTannotation.class));
   }
 
   @Override

--- a/src/main/jjtree-sources/DdlParser.head
+++ b/src/main/jjtree-sources/DdlParser.head
@@ -25,6 +25,7 @@ cat src/main/jjtree-sources/DdlParser.head       \
       src/main/jjtree-sources/ddl_keywords.jjt   \
       src/main/jjtree-sources/ddl_string_bytes_tokens.jjt \
       src/main/jjtree-sources/ddl_expression.jjt \
+      src/main/jjtree-sources/ddl_annotation.jjt \
       src/main/jjtree-sources/ddl_parser.jjt     \
    > src/main/jjtree/DdlParser.jjt
 

--- a/src/main/jjtree-sources/ddl_annotation.jjt
+++ b/src/main/jjtree-sources/ddl_annotation.jjt
@@ -1,3 +1,40 @@
+//
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Column Annotations are NOT a feature of Cloud Spanner.
+//
+// This is an additional feature of the Cloud Spanner Schema parser exclusively
+// in this tool so that users of this tool can add metadata to colums, and have
+// that metadata represented in the parsed schema.
+//
+// To use Annotations, they should be added to a CREATE TABLE statement as
+// follows:
+//
+// CREATE TABLE Albums (
+//  -- @ANNOTATION SOMETEXT,
+//   id STRING(36),
+// ) PRIMARY KEY (id)
+//
+// Annotations need to be on their own line, and terminate with a comma.
+// (This is because the '-- ' prefix is removed before using the JJT parser).
+//
+// As they are comments, they are ignored by the diff generator and by
+// Spanner itself.
+//
+
 TOKEN:
 {
   <ANNOTATION: "@ANNOTATION">

--- a/src/main/jjtree-sources/ddl_annotation.jjt
+++ b/src/main/jjtree-sources/ddl_annotation.jjt
@@ -1,0 +1,24 @@
+TOKEN:
+{
+  <ANNOTATION: "@ANNOTATION">
+}
+
+void column_annotation() #void: {}
+{
+  <ANNOTATION> annotation()
+}
+
+void annotation(): {}
+{
+  qualified_identifier() #name [ annotation_params() ]
+}
+
+void annotation_params() #void: {}
+{
+  "(" annotation_param() ( "," annotation_param() )* ")"
+}
+
+void annotation_param(): {}
+{
+  identifier() #param_key [ "=" identifier() #param_val ]
+}

--- a/src/main/jjtree-sources/ddl_parser.jjt
+++ b/src/main/jjtree-sources/ddl_parser.jjt
@@ -212,6 +212,7 @@ void table_element() #void :
     LOOKAHEAD(3) foreign_key()
   | LOOKAHEAD(3) check_constraint()
   | LOOKAHEAD(3) synonym_clause()
+  | column_annotation()
   | column_def()
 }
 

--- a/src/main/jjtree-sources/ddl_parser.jjt
+++ b/src/main/jjtree-sources/ddl_parser.jjt
@@ -212,7 +212,11 @@ void table_element() #void :
     LOOKAHEAD(3) foreign_key()
   | LOOKAHEAD(3) check_constraint()
   | LOOKAHEAD(3) synonym_clause()
+
+  // Column annotations are not a Spanner feature.
+  // See file ddl_annotation.jjt for more details.
   | column_annotation()
+
   | column_def()
 }
 

--- a/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLAnnotationTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLAnnotationTest.java
@@ -1,0 +1,59 @@
+package com.google.cloud.solutions.spannerddl.parser;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.solutions.spannerddl.testUtils.ReadTestDatafile;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Test;
+
+public class DDLAnnotationTest {
+
+  @Test
+  public void validateAnnotations() throws IOException {
+    Map<String, String> tests = ReadTestDatafile.readDdlSegmentsFromFile("annotations.txt");
+    Map<String, String> expects =
+        ReadTestDatafile.readDdlSegmentsFromFile("expectedAnnotations.txt");
+
+    Iterator<Entry<String, String>> testIt = tests.entrySet().iterator();
+    Iterator<Entry<String, String>> expectedIt = expects.entrySet().iterator();
+
+    while (testIt.hasNext() && expectedIt.hasNext()) {
+      Entry<String, String> test = testIt.next();
+      String expected = expectedIt.next().getValue();
+      String segmentName = test.getKey();
+
+      try {
+        DdlParser parser = new DdlParser(new StringReader(test.getValue()));
+        parser.ddl_statement();
+        Node tableStatement = parser.jjtree.rootNode().jjtGetChild(0);
+
+        // get all annotations
+        List<String> annotations = new ArrayList<>();
+        for (int i = 0, count = tableStatement.jjtGetNumChildren(); i < count; i++) {
+          Node child = tableStatement.jjtGetChild(i);
+          if (child instanceof ASTannotation) {
+            annotations.add(((ASTannotation) child).getAnnotation());
+          }
+        }
+
+        List<String> expectedList =
+            expected != null ? Arrays.asList(expected.split("\n")) : Collections.emptyList();
+
+        assertWithMessage("Mismatch for section " + segmentName)
+            .that(annotations)
+            .isEqualTo(expectedList);
+      } catch (ParseException e) {
+        fail("Failed to parse section: '" + segmentName + "': " + e);
+      }
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/solutions/spannerddl/testUtils/ReadTestDatafile.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/testUtils/ReadTestDatafile.java
@@ -32,6 +32,16 @@ public abstract class ReadTestDatafile {
    * @return LinkedHashMap of segment name => contents
    */
   public static Map<String, String> readDdlSegmentsFromFile(String filename) throws IOException {
+    return readDdlSegmentsFromFile(filename, false);
+  }
+
+  /**
+   * Reads the test data file, parsing out the test titles and data from the file.
+   *
+   * @return LinkedHashMap of segment name => contents
+   */
+  public static Map<String, String> readDdlSegmentsFromFile(String filename, boolean preserveSpace)
+      throws IOException {
     File file = new File("src/test/resources/" + filename).getAbsoluteFile();
     LinkedHashMap<String, String> output = new LinkedHashMap<>();
 
@@ -39,9 +49,9 @@ public abstract class ReadTestDatafile {
 
       String sectionName = null;
       StringBuilder section = new StringBuilder();
-      String line;
-      while (null != (line = in.readLine())) {
-        line = line.replaceAll("#.*", "").trim();
+      String rawLine;
+      while (null != (rawLine = in.readLine())) {
+        String line = preserveSpace ? rawLine : rawLine.replaceAll("#.*", "").trim();
         if (line.isEmpty()) {
           continue;
         }

--- a/src/test/resources/annotations.txt
+++ b/src/test/resources/annotations.txt
@@ -1,11 +1,11 @@
 == Test 1 all column annotations
 
 CREATE TABLE test1 (
-  @ANNOTATION DEPRECATED,
-  @ANNOTATION PII,
-  @ANNOTATION TAG.business(internal),
-  @ANNOTATION TAG.business(key1,key2),
-  @ANNOTATION TAG.business(key1=val1,key2=value),
+  -- @ANNOTATION DEPRECATED,
+  -- @ANNOTATION PII,
+  -- @ANNOTATION TAG.business(internal),
+  -- @ANNOTATION TAG.business(key1,key2),
+  -- @ANNOTATION TAG.business(key1=val1,key2=value),
   id STRING(36),
 ) PRIMARY KEY (id)
 

--- a/src/test/resources/annotations.txt
+++ b/src/test/resources/annotations.txt
@@ -1,0 +1,12 @@
+== Test 1 all column annotations
+
+CREATE TABLE test1 (
+  @ANNOTATION DEPRECATED,
+  @ANNOTATION PII,
+  @ANNOTATION TAG.business(internal),
+  @ANNOTATION TAG.business(key1,key2),
+  @ANNOTATION TAG.business(key1=val1,key2=value),
+  id STRING(36),
+) PRIMARY KEY (id)
+
+==

--- a/src/test/resources/expectedAnnotations.txt
+++ b/src/test/resources/expectedAnnotations.txt
@@ -1,0 +1,9 @@
+== Test 1 all column annotations
+
+DEPRECATED
+PII
+TAG.business(internal)
+TAG.business(key1,key2)
+TAG.business(key1=val1,key2=value)
+
+==

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -331,4 +331,8 @@ ALTER SEARCH INDEX AlbumsIndex DROP STORED COLUMN scol1
 
 == TEST 63 Recorder annotations should not generate a diff
 
+== TEST 64 Adding annotation as well as column should only generate the column diff
+
+ALTER TABLE AlbumsIndex ADD COLUMN new_col STRING(255)
+
 ==

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -325,6 +325,10 @@ ALTER SEARCH INDEX AlbumsIndex ADD STORED COLUMN scol1
 
 ALTER SEARCH INDEX AlbumsIndex DROP STORED COLUMN scol1
 
+== TEST 61 Add annotations to columns should not generate a diff
+
+== TEST 62 Remove annotations from columns should not generate a diff
+
+== TEST 63 Recorder annotations should not generate a diff
+
 ==
-
-

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -514,7 +514,7 @@ ON Albums (col1, col2)
 == TEST 61 Add annotations to columns should not generate a diff
 
 CREATE TABLE AlbumsIndex (
-  @ANNOTATION DEPRECATED,
+  -- @ANNOTATION DEPRECATED,
   id STRING(36),
 ) PRIMARY KEY (id)
 
@@ -527,15 +527,15 @@ CREATE TABLE AlbumsIndex (
 == TEST 63 Recorder annotations should not generate a diff
 
 CREATE TABLE AlbumsIndex (
-  @ANNOTATION PII,
-  @ANNOTATION DEPRECATED,
+  -- @ANNOTATION PII,
+  -- @ANNOTATION DEPRECATED,
   id STRING(36),
 ) PRIMARY KEY (id)
 
 == TEST 64 Adding annotation as well as column should only generate the column diff
 
 CREATE TABLE AlbumsIndex (
-  @ANNOTATION PII,
+  -- @ANNOTATION PII,
   id STRING(36),
   new_col STRING(255),
 ) PRIMARY KEY (id)

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -532,4 +532,12 @@ CREATE TABLE AlbumsIndex (
   id STRING(36),
 ) PRIMARY KEY (id)
 
+== TEST 64 Adding annotation as well as column should only generate the column diff
+
+CREATE TABLE AlbumsIndex (
+  @ANNOTATION PII,
+  id STRING(36),
+  new_col STRING(255),
+) PRIMARY KEY (id)
+
 ==

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -511,4 +511,25 @@ STORING (scol1);
 CREATE SEARCH INDEX AlbumsIndex
 ON Albums (col1, col2)
 
+== TEST 61 Add annotations to columns should not generate a diff
+
+CREATE TABLE AlbumsIndex (
+  @ANNOTATION DEPRECATED,
+  id STRING(36),
+) PRIMARY KEY (id)
+
+== TEST 62 Remove annotations from columns should not generate a diff
+
+CREATE TABLE AlbumsIndex (
+  id STRING(36),
+) PRIMARY KEY (id)
+
+== TEST 63 Recorder annotations should not generate a diff
+
+CREATE TABLE AlbumsIndex (
+  @ANNOTATION PII,
+  @ANNOTATION DEPRECATED,
+  id STRING(36),
+) PRIMARY KEY (id)
+
 ==

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -530,4 +530,10 @@ CREATE TABLE AlbumsIndex (
   id STRING(36),
 ) PRIMARY KEY (id)
 
+== TEST 64 Adding annotation as well as column should only generate the column diff
+
+CREATE TABLE AlbumsIndex (
+  id STRING(36),
+) PRIMARY KEY (id)
+
 ==

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -518,15 +518,15 @@ CREATE TABLE AlbumsIndex (
 == TEST 62 Remove annotations from columns should not generate a diff
 
 CREATE TABLE AlbumsIndex (
-  @ANNOTATION DEPRECATED,
+  -- @ANNOTATION DEPRECATED,
   id STRING(36),
 ) PRIMARY KEY (id)
 
 == TEST 63 Recorder annotations should not generate a diff
 
 CREATE TABLE AlbumsIndex (
-  @ANNOTATION DEPRECATED,
-  @ANNOTATION PII,
+  -- @ANNOTATION DEPRECATED,
+  -- @ANNOTATION PII,
   id STRING(36),
 ) PRIMARY KEY (id)
 

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -509,4 +509,25 @@ CREATE SEARCH INDEX AlbumsIndex
 ON Albums (col1, col2)
 STORING (scol1)
 
+== TEST 61 Add annotations to columns should not generate a diff
+
+CREATE TABLE AlbumsIndex (
+  id STRING(36),
+) PRIMARY KEY (id)
+
+== TEST 62 Remove annotations from columns should not generate a diff
+
+CREATE TABLE AlbumsIndex (
+  @ANNOTATION DEPRECATED,
+  id STRING(36),
+) PRIMARY KEY (id)
+
+== TEST 63 Recorder annotations should not generate a diff
+
+CREATE TABLE AlbumsIndex (
+  @ANNOTATION DEPRECATED,
+  @ANNOTATION PII,
+  id STRING(36),
+) PRIMARY KEY (id)
+
 ==


### PR DESCRIPTION
Spanner DDL SQL is often checked into source control. During the CI build there is often need to:
- Generate delta DDL and upgrade the Spanner schema. This tool already supports it
- Use the Spanner schema information in other build steps

Since Spanner DDL is an important source of truth, it useful to annotate the schema with meta information. One such use case to to support annotations on table columns like:
```
CREATE TABLE test1 (
  -- @ANNOTATION DEPRECATED,
  -- @ANNOTATION PII,
  -- @ANNOTATION PII.LEVEL_1(key1=val1,key2=value),
  id STRING(36),
) PRIMARY KEY (id)
```

This concept is similar to Java annotations where tools like javadoc can generated documentation based on the annotations. Some of the use cases of annotations:
- Mark a column deprecated
- Mark the column with PII tags

Since the `@ANNOTATION` is not a valid SQL statement, it is added as comment in the file. The annotations are parsed into AST and will become part of DatabaseDefinition. There is no delta generation as Spanner does not understand annotations or does not even support comments.

The CI build steps can use table column annotation.
