### PR TITLE
fix: delta generation for SEARCH INDEX as the ASC keyword is not supported

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_search_index_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_search_index_statement.java
@@ -266,7 +266,7 @@ public class ASTcreate_search_index_statement extends SimpleNode
           "Adding token colum {} for search index: {}", newToken.getKeyPath(), original.getName());
 
       createStatements.add(
-          "ALTER SEARCH INDEX " + original.getName() + " ADD COLUMN " + newToken.toString());
+          "ALTER SEARCH INDEX " + original.getName() + " ADD COLUMN " + newToken.getKeyPath());
     }
 
     for (ASTstored_column newStoredCol : storedColDiff.entriesOnlyOnRight().values()) {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_search_index_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_search_index_statement.java
@@ -189,18 +189,17 @@ public class ASTcreate_search_index_statement extends SimpleNode
     // Look for differences in tokenKeyList
     // Easiest is to use Maps.difference, but first we need some maps, and we need to preserve order
     // so convert the keyParts to String, and then add to a LinkedHashMap.
-    Map<String, ASTkey_part> originalKeyParts =
-        getChildByType(original.children, ASTtoken_key_list.class).getKeyParts().stream()
+    Map<String, ASTpath> originalKeyParts =
+        getChildByType(original.children, ASTtoken_key_list.class).getPaths().stream()
             .collect(
                 Collectors.toMap(
-                    ASTkey_part::toString, Function.identity(), (x, y) -> y, LinkedHashMap::new));
-    Map<String, ASTkey_part> newKeyParts =
-        getChildByType(other.children, ASTtoken_key_list.class).getKeyParts().stream()
+                    ASTpath::toString, Function.identity(), (x, y) -> y, LinkedHashMap::new));
+    Map<String, ASTpath> newKeyParts =
+        getChildByType(other.children, ASTtoken_key_list.class).getPaths().stream()
             .collect(
                 Collectors.toMap(
-                    ASTkey_part::toString, Function.identity(), (x, y) -> y, LinkedHashMap::new));
-    MapDifference<String, ASTkey_part> keyPartsDiff =
-        Maps.difference(originalKeyParts, newKeyParts);
+                    ASTpath::toString, Function.identity(), (x, y) -> y, LinkedHashMap::new));
+    MapDifference<String, ASTpath> keyPartsDiff = Maps.difference(originalKeyParts, newKeyParts);
 
     // Look for differences in storedColumnList
     // Easiest is to use Maps.difference, but first we need some maps, and we need to preserve order
@@ -234,17 +233,17 @@ public class ASTcreate_search_index_statement extends SimpleNode
         Maps.difference(originalStoredColumns, newStoredColumns);
 
     if (allowDropColumnStatements) {
-      for (ASTkey_part droppedToken : keyPartsDiff.entriesOnlyOnLeft().values()) {
+      for (ASTpath droppedTokenCol : keyPartsDiff.entriesOnlyOnLeft().values()) {
         LOG.info(
             "Dropping token colum {} for search index: {}",
-            droppedToken.getKeyPath(),
+            droppedTokenCol.toString(),
             original.getName());
 
         dropStatements.add(
             "ALTER SEARCH INDEX "
                 + original.getName()
                 + " DROP COLUMN "
-                + droppedToken.getKeyPath());
+                + droppedTokenCol.toString());
       }
     }
 
@@ -261,12 +260,12 @@ public class ASTcreate_search_index_statement extends SimpleNode
               + droppedStoredCol.toString());
     }
 
-    for (ASTkey_part newToken : keyPartsDiff.entriesOnlyOnRight().values()) {
+    for (ASTpath newToken : keyPartsDiff.entriesOnlyOnRight().values()) {
       LOG.info(
-          "Adding token colum {} for search index: {}", newToken.getKeyPath(), original.getName());
+          "Adding token colum {} for search index: {}", newToken.toString(), original.getName());
 
       createStatements.add(
-          "ALTER SEARCH INDEX " + original.getName() + " ADD COLUMN " + newToken.getKeyPath());
+          "ALTER SEARCH INDEX " + original.getName() + " ADD COLUMN " + newToken.toString());
     }
 
     for (ASTstored_column newStoredCol : storedColDiff.entriesOnlyOnRight().values()) {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtoken_key_list.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtoken_key_list.java
@@ -20,6 +20,7 @@ import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ASTtoken_key_list extends SimpleNode {
   public ASTtoken_key_list(int id) {
@@ -37,7 +38,9 @@ public class ASTtoken_key_list extends SimpleNode {
   @Override
   public String toString() {
     validateChildren();
-    return "( " + Joiner.on(", ").join(getKeyParts()) + " )";
+    List<String> keyPaths =
+        getKeyParts().stream().map(ASTkey_part::getKeyPath).collect(Collectors.toList());
+    return "( " + Joiner.on(", ").join(keyPaths) + " )";
   }
 
   public List<ASTkey_part> getKeyParts() {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtoken_key_list.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtoken_key_list.java
@@ -20,7 +20,6 @@ import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ASTtoken_key_list extends SimpleNode {
   public ASTtoken_key_list(int id) {
@@ -32,19 +31,17 @@ public class ASTtoken_key_list extends SimpleNode {
   }
 
   private void validateChildren() {
-    AstTreeUtils.validateChildrenClasses(children, ImmutableSet.of(ASTkey_part.class));
+    AstTreeUtils.validateChildrenClasses(children, ImmutableSet.of(ASTpath.class));
   }
 
   @Override
   public String toString() {
     validateChildren();
-    List<String> keyPaths =
-        getKeyParts().stream().map(ASTkey_part::getKeyPath).collect(Collectors.toList());
-    return "( " + Joiner.on(", ").join(keyPaths) + " )";
+    return "( " + Joiner.on(", ").join(getPaths()) + " )";
   }
 
-  public List<ASTkey_part> getKeyParts() {
-    return AstTreeUtils.getChildrenAssertType(children, ASTkey_part.class);
+  public List<ASTpath> getPaths() {
+    return AstTreeUtils.getChildrenAssertType(children, ASTpath.class);
   }
 
   @Override

--- a/src/main/jjtree-sources/ddl_parser.jjt
+++ b/src/main/jjtree-sources/ddl_parser.jjt
@@ -175,8 +175,8 @@ void alter_search_index_statement() :
   <SEARCH><INDEX> (qualified_identifier() #name)
   (   LOOKAHEAD(2) <ADD> <STORED> <COLUMN> stored_column() #add_stored_column
     | LOOKAHEAD(2) <DROP> <STORED> <COLUMN> identifier() #drop_stored_column_name
-    | LOOKAHEAD(2) <ADD> <COLUMN> key_part() #add_token_column
-    | LOOKAHEAD(2) <DROP> <COLUMN> key_part() #drop_token_column
+    | LOOKAHEAD(2) <ADD> <COLUMN> path() #add_token_column
+    | LOOKAHEAD(2) <DROP> <COLUMN> path() #drop_token_column
   )
 }
 
@@ -410,8 +410,8 @@ void token_key_list() :
 {}
 {
   "("
-    [ key_part()
-      ("," key_part() )*
+    [ path()
+      ("," path() )*
     ]
   ")"
 }

--- a/src/test/resources/ddlParserValidation.txt
+++ b/src/test/resources/ddlParserValidation.txt
@@ -137,7 +137,7 @@ CREATE CHANGE STREAM change_stream_name FOR table1, table2 ( ), table3 ( col1, c
 == Test 13a create search index full
 
 CREATE SEARCH INDEX AlbumsIndex
-ON Albums ( AlbumTitle_Tokens ASC, Rating_Tokens ASC )
+ON Albums ( AlbumTitle_Tokens, Rating_Tokens )
 STORING ( Genre, albumName )
 PARTITION BY SingerId ASC
 ORDER BY ReleaseTimestamp DESC
@@ -148,7 +148,7 @@ OPTIONS (sort_order_sharding=TRUE)
 == Test 13b create search index Simple
 
 CREATE SEARCH INDEX AlbumsIndex
-ON Albums ( AlbumTitle_Tokens ASC )
+ON Albums ( AlbumTitle_Tokens )
 OPTIONS (sort_order_sharding=TRUE)
 
 ==

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -297,7 +297,7 @@ ALTER INDEX test4 ADD STORED COLUMN col5
 
 CREATE TABLE test2 ( col1 INT64 ) PRIMARY KEY (col1 ASC)
 
-CREATE SEARCH INDEX AlbumsIndex ON Albums ( AlbumTitle_Tokens ASC )
+CREATE SEARCH INDEX AlbumsIndex ON Albums ( AlbumTitle_Tokens )
 
 == TEST 56 Dropping search index - before table dropping
 
@@ -310,12 +310,12 @@ ALTER SEARCH INDEX AlbumsIndex DROP COLUMN col2
 ALTER SEARCH INDEX AlbumsIndex DROP STORED COLUMN scol2
 ALTER TABLE test1 DROP COLUMN col2
 ALTER TABLE test1 ADD COLUMN col3 INT64
-ALTER SEARCH INDEX AlbumsIndex ADD COLUMN col3 ASC
+ALTER SEARCH INDEX AlbumsIndex ADD COLUMN col3
 ALTER SEARCH INDEX AlbumsIndex ADD STORED COLUMN scol3
 
 == TEST 58 Add col to search index - no stored columns
 
-ALTER SEARCH INDEX AlbumsIndex ADD COLUMN col3 ASC
+ALTER SEARCH INDEX AlbumsIndex ADD COLUMN col3
 
 == TEST 59 Add stored col to search index
 

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -482,7 +482,7 @@ create table test1 ( col1 int64 ) primary key (col1);
 
 create table test2 ( col1 int64 ) primary key (col1);
 
-CREATE SEARCH INDEX AlbumsIndex ON Albums ( AlbumTitle_Tokens ASC, Rating_Tokens ASC )
+CREATE SEARCH INDEX AlbumsIndex ON Albums ( AlbumTitle_Tokens, Rating_Tokens )
 
 == TEST 57 Changing search index - before and after table changes
 


### PR DESCRIPTION
The token column list of SEARCH INDEX does not support ASC/DESC keyword with the new Enterprise edition