### PR TITLE
fix: do not capitalize reserved words for object names

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_change_stream_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_change_stream_statement.java
@@ -28,7 +28,7 @@ public class ASTcreate_change_stream_statement extends SimpleNode {
   }
 
   public String getName() {
-    return AstTreeUtils.getChildByType(children, ASTname.class).toString();
+    return AstTreeUtils.tokensToString(AstTreeUtils.getChildByType(children, ASTname.class), false);
   }
 
   public ASTchange_stream_for_clause getForClause() {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_index_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_index_statement.java
@@ -38,7 +38,7 @@ public class ASTcreate_index_statement extends SimpleNode
   }
 
   public String getIndexName() {
-    return AstTreeUtils.getChildByType(children, ASTname.class).toString();
+    return AstTreeUtils.tokensToString(AstTreeUtils.getChildByType(children, ASTname.class), false);
   }
 
   @Override

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_search_index_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_search_index_statement.java
@@ -50,7 +50,7 @@ public class ASTcreate_search_index_statement extends SimpleNode
   }
 
   public String getName() {
-    return AstTreeUtils.tokensToString(getChildByType(children, ASTname.class));
+    return AstTreeUtils.tokensToString(AstTreeUtils.getChildByType(children, ASTname.class), false);
   }
 
   private void validateChildren() {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
@@ -44,7 +44,7 @@ public class ASTcreate_table_statement extends SimpleNode {
   }
 
   public String getTableName() {
-    return AstTreeUtils.tokensToString(AstTreeUtils.getChildByType(children, ASTname.class));
+    return AstTreeUtils.tokensToString(AstTreeUtils.getChildByType(children, ASTname.class), false);
   }
 
   public Map<String, ASTcolumn_def> getColumns() {

--- a/src/test/resources/ddlParserValidation.txt
+++ b/src/test/resources/ddlParserValidation.txt
@@ -151,4 +151,26 @@ CREATE SEARCH INDEX AlbumsIndex
 ON Albums ( AlbumTitle_Tokens )
 OPTIONS (sort_order_sharding=TRUE)
 
+== Test 14 create table with reserved word word name
+
+CREATE TABLE usage (
+  intcol INT64,
+  structcol1 STRUCT < col1 INT64, col2 INT64 >,
+  structcol2 STRUCT <>
+) PRIMARY KEY (intcol ASC)
+
+== Test 15 create index with reserved word word name
+
+CREATE INDEX IF NOT EXISTS usage ON usage_table ( mycol ASC )
+
+== Test 16 create search index with reserved word name
+
+CREATE SEARCH INDEX usage
+ON usage_table ( some_token )
+OPTIONS (sort_order_sharding=TRUE)
+
+== Test 16 change stream with reserved word name
+
+CREATE CHANGE STREAM usage FOR table1
+
 ==


### PR DESCRIPTION
Tables which were named using reserved words were having their names normalized - ie capitalized. 

Fix and add tests. 