### PR TITLE
feat: Support for CREATE SCHEMA statements

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -27,6 +27,8 @@ import com.google.cloud.solutions.spannerddl.parser.ASTcolumn_default_clause;
 import com.google.cloud.solutions.spannerddl.parser.ASTcolumn_type;
 import com.google.cloud.solutions.spannerddl.parser.ASTcreate_change_stream_statement;
 import com.google.cloud.solutions.spannerddl.parser.ASTcreate_index_statement;
+import com.google.cloud.solutions.spannerddl.parser.ASTcreate_or_replace_statement;
+import com.google.cloud.solutions.spannerddl.parser.ASTcreate_schema_statement;
 import com.google.cloud.solutions.spannerddl.parser.ASTcreate_search_index_statement;
 import com.google.cloud.solutions.spannerddl.parser.ASTcreate_table_statement;
 import com.google.cloud.solutions.spannerddl.parser.ASTddl_statement;
@@ -100,6 +102,7 @@ public class DdlDiff {
   private final MapDifference<String, ASTcreate_change_stream_statement> changeStreamDifferences;
   private final MapDifference<String, ASTcreate_search_index_statement> searchIndexDifferences;
   private final String databaseName; // for alter Database
+  private final MapDifference<String, ASTcreate_schema_statement> schemaDifferences;
 
   private DdlDiff(DatabaseDefinition originalDb, DatabaseDefinition newDb, String databaseName)
       throws DdlDiffException {
@@ -118,6 +121,7 @@ public class DdlDiff {
         Maps.difference(originalDb.changeStreams(), newDb.changeStreams());
     this.searchIndexDifferences =
         Maps.difference(originalDb.searchIndexes(), newDb.searchIndexes());
+    this.schemaDifferences = Maps.difference(originalDb.schemas(), newDb.schemas());
 
     if (!alterDatabaseOptionsDifferences.areEqual() && Strings.isNullOrEmpty(databaseName)) {
       // should never happen, but...
@@ -158,6 +162,12 @@ public class DdlDiff {
               + ALLOW_RECREATE_CONSTRAINTS_OPT
               + " is not set.\n"
               + Joiner.on(", ").join(constraintDifferences.entriesDiffering().keySet()));
+    }
+
+    if (!schemaDifferences.entriesDiffering().isEmpty()) {
+      throw new DdlDiffException(
+          "At least one schema differs but ALTER SCHEMA is not supported"
+              + Joiner.on(", ").join(schemaDifferences.entriesDiffering().keySet()));
     }
 
     // check for modified Alter Database statements
@@ -247,12 +257,26 @@ public class DdlDiff {
       }
     }
 
+    // Drop schemas
+    if (options.get(ALLOW_DROP_STATEMENTS_OPT)) {
+      for (ASTcreate_schema_statement schema : schemaDifferences.entriesOnlyOnLeft().values()) {
+        LOG.info("Dropping schema: {}", schema.getName());
+        output.add("DROP SCHEMA " + schema.getName());
+      }
+    }
+
     // Alter existing tables, or error if not possible.
     for (ValueDifference<ASTcreate_table_statement> difference :
         tableDifferences.entriesDiffering().values()) {
       LOG.info("Altering modified table: {}", difference.leftValue().getTableName());
       output.addAll(
           generateAlterTableStatements(difference.leftValue(), difference.rightValue(), options));
+    }
+
+    // create schemas
+    for (ASTcreate_schema_statement schema : schemaDifferences.entriesOnlyOnRight().values()) {
+      LOG.info("creating schema: {}", schema.getName());
+      output.add(schema.toString());
     }
 
     // Create new tables. Must be done in the order of creation in the new DDL.
@@ -755,8 +779,8 @@ public class DdlDiff {
                   "Unsupported statement:\n"
                       + statement
                       + "\n"
-                      + "Can only create diffs from 'CREATE TABLE, CREATE INDEX and 'ALTER TABLE"
-                      + " table_name ADD [constraint|row deletion policy]' DDL statements");
+                      + "ALTER TABLE statements only support 'ADD [constraint|row deletion"
+                      + " policy]'");
             }
             if (alterTableStatement.jjtGetChild(1) instanceof ASTforeign_key
                 && ((ASTforeign_key) alterTableStatement.jjtGetChild(1))
@@ -791,14 +815,24 @@ public class DdlDiff {
           case DdlParserTreeConstants.JJTALTER_DATABASE_STATEMENT:
           case DdlParserTreeConstants.JJTCREATE_CHANGE_STREAM_STATEMENT:
           case DdlParserTreeConstants.JJTCREATE_SEARCH_INDEX_STATEMENT:
-            // no-op
+            // no-op - allowed
+            break;
+          case DdlParserTreeConstants.JJTCREATE_OR_REPLACE_STATEMENT:
+            // can be one of several types.
+            switch (((ASTcreate_or_replace_statement) ddlStatement.jjtGetChild(0))
+                .getSchemaObject()
+                .getId()) {
+              case DdlParserTreeConstants.JJTCREATE_SCHEMA_STATEMENT:
+                // no-op - allowed
+                break;
+              default:
+                throw new IllegalArgumentException(
+                    "Unsupported statement for creating diffs:\n" + statement);
+            }
             break;
           default:
             throw new IllegalArgumentException(
-                "Unsupported statement:\n"
-                    + statement
-                    + "\nCan only create diffs from 'CREATE TABLE, CREATE INDEX, and "
-                    + "'ALTER TABLE table_name ADD CONSTRAINT' DDL statements");
+                "Unsupported statement for creating diffs:\n" + statement);
         }
         ddlStatements.add(ddlStatement);
       } catch (ParseException e) {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_or_replace_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_or_replace_statement.java
@@ -15,6 +15,11 @@
  */
 package com.google.cloud.solutions.spannerddl.parser;
 
+import static com.google.cloud.solutions.spannerddl.diff.AstTreeUtils.getOptionalChildByType;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
 public class ASTcreate_or_replace_statement extends SimpleNode {
   public ASTcreate_or_replace_statement(int id) {
     super(id);
@@ -22,5 +27,31 @@ public class ASTcreate_or_replace_statement extends SimpleNode {
 
   public ASTcreate_or_replace_statement(DdlParser p, int id) {
     super(p, id);
+  }
+
+  public SimpleNode getSchemaObject() {
+    return Stream.of(
+            getOptionalChildByType(children, ASTcreate_view_statement.class),
+            getOptionalChildByType(children, ASTcreate_model_statement.class),
+            getOptionalChildByType(children, ASTcreate_schema_statement.class))
+        .filter(Objects::nonNull)
+        .findFirst()
+        .get();
+  }
+
+  @Override
+  public String toString() {
+    return getSchemaObject().toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return getSchemaObject().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof ASTcreate_or_replace_statement
+        && getSchemaObject().equals(((ASTcreate_or_replace_statement) obj).getSchemaObject());
   }
 }

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_schema_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_schema_statement.java
@@ -15,15 +15,56 @@
  */
 package com.google.cloud.solutions.spannerddl.parser;
 
-// TODO
+import static com.google.cloud.solutions.spannerddl.diff.AstTreeUtils.getChildByType;
+import static com.google.cloud.solutions.spannerddl.diff.AstTreeUtils.getOptionalChildByType;
+
+import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+
 public class ASTcreate_schema_statement extends SimpleNode {
   public ASTcreate_schema_statement(int id) {
     super(id);
-    throw new UnsupportedOperationException("Not Implemented");
   }
 
   public ASTcreate_schema_statement(DdlParser p, int id) {
     super(p, id);
-    throw new UnsupportedOperationException("Not Implemented");
+  }
+
+  private void validateChildren() {
+    AstTreeUtils.validateChildrenClasses(
+        children, ImmutableSet.of(ASTif_not_exists.class, ASTname.class, ASToptions_clause.class));
+  }
+
+  @Override
+  public String toString() {
+    return toStringOptionalExistClause(true);
+  }
+
+  public String getName() {
+    return getChildByType(children, ASTname.class).toString();
+  }
+
+  /** Create string version, optionally including the IF NOT EXISTS clause */
+  public String toStringOptionalExistClause(boolean includeExists) {
+    validateChildren();
+    return Joiner.on(" ")
+        .skipNulls()
+        .join(
+            "CREATE",
+            "SCHEMA",
+            (includeExists ? getOptionalChildByType(children, ASTif_not_exists.class) : null),
+            getName(),
+            AstTreeUtils.getOptionalChildByType(children, ASToptions_clause.class));
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return (obj instanceof ASTcreate_schema_statement) && toString().equals(obj.toString());
+  }
+
+  @Override
+  public int hashCode() {
+    return toString().hashCode();
   }
 }

--- a/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffFromFilesTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffFromFilesTest.java
@@ -78,12 +78,13 @@ public class DdlDiffFromFilesTest {
 
         // TEST PART 2: with allowDropStatements=false
 
-        // build an expectedResults without any column or table drops.
+        // build an expectedResults without any drops.
         List<String> expectedDiffNoDrops =
             expectedDiff.stream()
                 .filter(
                     statement ->
-                        !statement.matches(".*DROP (TABLE|COLUMN|CHANGE STREAM|SEARCH INDEX).*"))
+                        !statement.matches(
+                            ".*DROP (SCHEMA|TABLE|COLUMN|CHANGE STREAM|SEARCH INDEX).*"))
                 .collect(Collectors.toList());
 
         // remove any drop indexes from the expectedResults if they do not have an equivalent

--- a/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLParserFromFileTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLParserFromFileTest.java
@@ -35,9 +35,10 @@ public class DDLParserFromFileTest {
         assertWithMessage("Mismatch for section " + segmentName + ":")
             .that(parsedStatement.toString())
             .isEqualTo(ddlStatement);
-      } catch (ParseException e) {
+      } catch (Throwable e) {
+        e.printStackTrace(System.err);
         fail(
-            "Failed to parse section: '"
+            "Exception when parsing section: '"
                 + segmentName
                 + "': "
                 + e

--- a/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLParserTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLParserTest.java
@@ -178,6 +178,14 @@ public class DDLParserTest {
     assertThat(statement).isEqualTo(statement2);
   }
 
+  @Test
+  public void ignoreCreateOrReplace() throws ParseException {
+    ASTcreate_or_replace_statement statement =
+        (ASTcreate_or_replace_statement)
+            parse("CREATE OR REPLACE SCHEMA schema_name").jjtGetChild(0);
+    assertThat(statement.toString()).isEqualTo("CREATE SCHEMA schema_name");
+  }
+
   private static void parseCheckingParseException(String ddlStatement, String exceptionContains) {
     ParseException e =
         assertThrows(ParseException.class, () -> parseAndVerifyToString(ddlStatement));

--- a/src/test/resources/ddlParserValidation.txt
+++ b/src/test/resources/ddlParserValidation.txt
@@ -173,4 +173,16 @@ OPTIONS (sort_order_sharding=TRUE)
 
 CREATE CHANGE STREAM usage FOR table1
 
+== Test 17 create schema
+
+CREATE SCHEMA schema_name
+
+== Test 18 create schema if not exists
+
+CREATE SCHEMA IF NOT EXISTS schema_name
+
+== Test 18 create schema with options
+
+CREATE SCHEMA IF NOT EXISTS schema_name OPTIONS (opt1=TRUE)
+
 ==

--- a/src/test/resources/expectedDdlDiff.txt
+++ b/src/test/resources/expectedDdlDiff.txt
@@ -335,4 +335,19 @@ ALTER SEARCH INDEX AlbumsIndex DROP STORED COLUMN scol1
 
 ALTER TABLE AlbumsIndex ADD COLUMN new_col STRING(255)
 
+== TEST 65 Adding new schema
+
+CREATE SCHEMA schema2
+
+== TEST 66 Dropping schema
+
+DROP SCHEMA schema2
+
+== TEST 67 Creating and dropping schema with tables in correct order
+
+DROP TABLE schema2.table1
+DROP SCHEMA schema2
+CREATE SCHEMA schema3
+CREATE TABLE schema3.table1 ( col1 INT64 ) PRIMARY KEY (col1 ASC)
+
 ==

--- a/src/test/resources/newDdl.txt
+++ b/src/test/resources/newDdl.txt
@@ -540,4 +540,27 @@ CREATE TABLE AlbumsIndex (
   new_col STRING(255),
 ) PRIMARY KEY (id)
 
+== TEST 65 Adding new schema
+
+CREATE SCHEMA schema1;
+CREATE SCHEMA schema2;
+
+== TEST 66 Dropping schema
+
+CREATE SCHEMA schema1;
+
+== TEST 67 Creating and dropping schema with tables in correct order
+
+CREATE SCHEMA schema1;
+
+CREATE TABLE schema1.table1 (
+  col1 INT64,
+)PRIMARY KEY (col1);
+
+CREATE SCHEMA schema3;
+
+CREATE TABLE schema3.table1 (
+  col1 INT64,
+)PRIMARY KEY (col1);
+
 ==

--- a/src/test/resources/originalDdl.txt
+++ b/src/test/resources/originalDdl.txt
@@ -536,4 +536,29 @@ CREATE TABLE AlbumsIndex (
   id STRING(36),
 ) PRIMARY KEY (id)
 
+== TEST 65 Adding new schema
+
+CREATE SCHEMA schema1;
+
+
+== TEST 66 Dropping schema
+
+CREATE SCHEMA schema1;
+CREATE SCHEMA schema2;
+
+== TEST 67 Creating and dropping schema with tables in correct order
+
+CREATE SCHEMA schema1;
+
+CREATE TABLE schema1.table1 (
+  col1 INT64,
+)PRIMARY KEY (col1);
+
+CREATE SCHEMA schema2;
+
+CREATE TABLE schema2.table1 (
+  col1 INT64,
+)PRIMARY KEY (col1);
+
+
 ==


### PR DESCRIPTION
This only allows for diffing DDLs with CREATE SCHEMA statements.

support for ROLEs and GRANTS are not included in this change

Fixes #195 