### PR TITLE
fix: support non-parent interleaving and parent enforcement changes

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -514,8 +514,8 @@ public class DdlDiff {
         alterStatements.add(
             "ALTER TABLE "
                 + left.getTableName()
-                + " SET INTERLEAVE IN "
-                + rightInterleave.getParentTableName());
+                + " SET "
+                + rightInterleave.getInterleaveTargetClause());
       }
     }
 

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -492,18 +492,31 @@ public class DdlDiff {
     //   - change not null on column.
     // note that constraints need to be dropped before columns, and created after columns.
 
-    // Check interleaving has not changed.
+    // The physical interleave relationship cannot change, but its enforcement can.
     if (left.getInterleaveClause().isPresent() != right.getInterleaveClause().isPresent()) {
       throw new DdlDiffException("Cannot change interleaving on table " + left.getTableName());
     }
 
-    if (left.getInterleaveClause().isPresent()
-        && !left.getInterleaveClause()
-            .get()
-            .getParentTableName()
-            .equals(right.getInterleaveClause().get().getParentTableName())) {
-      throw new DdlDiffException(
-          "Cannot change interleaved parent of table " + left.getTableName());
+    boolean interleaveEnforcementChanged = false;
+    if (left.getInterleaveClause().isPresent()) {
+      ASTtable_interleave_clause leftInterleave = left.getInterleaveClause().get();
+      ASTtable_interleave_clause rightInterleave = right.getInterleaveClause().get();
+      if (!leftInterleave
+          .getInterleaveTableName()
+          .equals(rightInterleave.getInterleaveTableName())) {
+        throw new DdlDiffException(
+            "Cannot change interleaved parent of table " + left.getTableName());
+      }
+
+      interleaveEnforcementChanged =
+          leftInterleave.isParentInterleave() != rightInterleave.isParentInterleave();
+      if (interleaveEnforcementChanged) {
+        alterStatements.add(
+            "ALTER TABLE "
+                + left.getTableName()
+                + " SET INTERLEAVE IN "
+                + rightInterleave.getParentTableName());
+      }
     }
 
     // Check Key is same
@@ -513,9 +526,12 @@ public class DdlDiff {
 
     // On delete changed
     if (left.getInterleaveClause().isPresent()
+        && right.getInterleaveClause().get().isParentInterleave()
         && !Objects.equals(
             left.getInterleaveClause().get().getOnDelete(),
-            right.getInterleaveClause().get().getOnDelete())) {
+            right.getInterleaveClause().get().getOnDelete())
+        && (!interleaveEnforcementChanged
+            || !"ON DELETE NO ACTION".equals(right.getInterleaveClause().get().getOnDelete()))) {
       alterStatements.add(
           "ALTER TABLE "
               + left.getTableName()

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -39,6 +39,7 @@ import com.google.cloud.solutions.spannerddl.parser.ASTkey_part;
 import com.google.cloud.solutions.spannerddl.parser.ASToptions_clause;
 import com.google.cloud.solutions.spannerddl.parser.ASTrow_deletion_policy_clause;
 import com.google.cloud.solutions.spannerddl.parser.ASTtable;
+import com.google.cloud.solutions.spannerddl.parser.ASTtable_interleave_clause;
 import com.google.cloud.solutions.spannerddl.parser.DdlParser;
 import com.google.cloud.solutions.spannerddl.parser.DdlParserTreeConstants;
 import com.google.cloud.solutions.spannerddl.parser.ParseException;
@@ -512,10 +513,9 @@ public class DdlDiff {
 
     // On delete changed
     if (left.getInterleaveClause().isPresent()
-        && !left.getInterleaveClause()
-            .get()
-            .getOnDelete()
-            .equals(right.getInterleaveClause().get().getOnDelete())) {
+        && !Objects.equals(
+            left.getInterleaveClause().get().getOnDelete(),
+            right.getInterleaveClause().get().getOnDelete())) {
       alterStatements.add(
           "ALTER TABLE "
               + left.getTableName()
@@ -853,7 +853,10 @@ public class DdlDiff {
             }
             break;
           case DdlParserTreeConstants.JJTCREATE_TABLE_STATEMENT:
-            if (((ASTcreate_table_statement) ddlStatement.jjtGetChild(0))
+            ASTcreate_table_statement createTable =
+                (ASTcreate_table_statement) ddlStatement.jjtGetChild(0);
+            createTable.getInterleaveClause().ifPresent(ASTtable_interleave_clause::validate);
+            if (createTable
                 .getConstraints()
                 .containsKey(ASTcreate_table_statement.ANONYMOUS_NAME)) {
               throw new IllegalArgumentException(

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtable_interleave_clause.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtable_interleave_clause.java
@@ -30,8 +30,8 @@ public class ASTtable_interleave_clause extends SimpleNode {
     super(p, id);
   }
 
-  public String getParentTableName() {
-    return (isParentInterleave() ? "PARENT " : "") + getInterleaveTableName();
+  public String getInterleaveTargetClause() {
+    return "INTERLEAVE IN " + (isParentInterleave() ? "PARENT " : "") + getInterleaveTableName();
   }
 
   public String getInterleaveTableName() {
@@ -67,6 +67,6 @@ public class ASTtable_interleave_clause extends SimpleNode {
 
   @Override
   public String toString() {
-    return Joiner.on(" ").skipNulls().join("INTERLEAVE IN", getParentTableName(), getOnDelete());
+    return Joiner.on(" ").skipNulls().join(getInterleaveTargetClause(), getOnDelete());
   }
 }

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtable_interleave_clause.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtable_interleave_clause.java
@@ -31,9 +31,12 @@ public class ASTtable_interleave_clause extends SimpleNode {
   }
 
   public String getParentTableName() {
-    return (isParentInterleave() ? "PARENT " : "")
-        + AstTreeUtils.tokensToString(
-            AstTreeUtils.getChildByType(children, ASTinterleave_in.class));
+    return (isParentInterleave() ? "PARENT " : "") + getInterleaveTableName();
+  }
+
+  public String getInterleaveTableName() {
+    return AstTreeUtils.tokensToString(
+        AstTreeUtils.getChildByType(children, ASTinterleave_in.class));
   }
 
   public boolean isParentInterleave() {

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtable_interleave_clause.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTtable_interleave_clause.java
@@ -18,6 +18,7 @@ package com.google.cloud.solutions.spannerddl.parser;
 
 import com.google.cloud.solutions.spannerddl.diff.AstTreeUtils;
 import com.google.common.base.Joiner;
+import org.jspecify.annotations.Nullable;
 
 /** Abstract Syntax Tree parser object for "table_interleave_clause" token */
 public class ASTtable_interleave_clause extends SimpleNode {
@@ -30,18 +31,34 @@ public class ASTtable_interleave_clause extends SimpleNode {
   }
 
   public String getParentTableName() {
-    return (AstTreeUtils.getOptionalChildByType(children, ASTparent.class) == null ? "" : "PARENT ")
+    return (isParentInterleave() ? "PARENT " : "")
         + AstTreeUtils.tokensToString(
             AstTreeUtils.getChildByType(children, ASTinterleave_in.class));
   }
 
-  public String getOnDelete() {
+  public boolean isParentInterleave() {
+    return AstTreeUtils.getOptionalChildByType(children, ASTparent.class) != null;
+  }
+
+  public @Nullable String getOnDelete() {
+    validate();
     ASTon_delete_clause ondelete =
         AstTreeUtils.getOptionalChildByType(children, ASTon_delete_clause.class);
+    if (!isParentInterleave()) {
+      return null;
+    }
     if (ondelete == null) {
       return ASTon_delete_clause.ON_DELETE_NO_ACTION;
     } else {
       return ondelete.toString();
+    }
+  }
+
+  public void validate() {
+    if (!isParentInterleave()
+        && AstTreeUtils.getOptionalChildByType(children, ASTon_delete_clause.class) != null) {
+      throw new IllegalArgumentException(
+          "ON DELETE is only valid for INTERLEAVE IN PARENT clauses");
     }
   }
 

--- a/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
@@ -334,15 +334,6 @@ public class DdlDiffTest {
         true,
         "Cannot change interleaved parent of table test1");
 
-    // add  parent constraint
-    getDiffCheckDdlDiffException(
-        "create table test1 (col1 int64, col2 int64) "
-            + "primary key (col1), interleave in testparent;",
-        "create table test1 (col1 int64, col2 int64) "
-            + "primary key (col1), interleave in parent testparent",
-        true,
-        "Cannot change interleaved parent of table test1");
-
     // change on delete
     assertThat(
             getDiff(
@@ -361,6 +352,57 @@ public class DdlDiffTest {
                     + "primary key (col1), interleave in parent testparent on delete cascade",
                 true))
         .containsExactly("ALTER TABLE test1 SET ON DELETE CASCADE");
+  }
+
+  @Test
+  public void generateAlterTable_removeInterleaveParentEnforcement() throws DdlDiffException {
+    assertThat(
+            getDiff(
+                "create table test1 (col1 int64, col2 int64) "
+                    + "primary key (col1), interleave in parent testparent on delete cascade;",
+                "create table test1 (col1 int64, col2 int64) "
+                    + "primary key (col1), interleave in testparent;",
+                true))
+        .containsExactly("ALTER TABLE test1 SET INTERLEAVE IN testparent");
+  }
+
+  @Test
+  public void generateAlterTable_addInterleaveParentEnforcement() throws DdlDiffException {
+    assertThat(
+            getDiff(
+                "create table test1 (col1 int64, col2 int64) "
+                    + "primary key (col1), interleave in testparent;",
+                "create table test1 (col1 int64, col2 int64) "
+                    + "primary key (col1), interleave in parent testparent;",
+                true))
+        .containsExactly("ALTER TABLE test1 SET INTERLEAVE IN PARENT testparent");
+  }
+
+  @Test
+  public void generateAlterTable_addInterleaveParentEnforcementWithCascade()
+      throws DdlDiffException {
+    assertThat(
+            getDiff(
+                "create table test1 (col1 int64, col2 int64) "
+                    + "primary key (col1), interleave in testparent;",
+                "create table test1 (col1 int64, col2 int64) "
+                    + "primary key (col1), interleave in parent testparent on delete cascade;",
+                true))
+        .containsExactly(
+            "ALTER TABLE test1 SET INTERLEAVE IN PARENT testparent",
+            "ALTER TABLE test1 SET ON DELETE CASCADE")
+        .inOrder();
+  }
+
+  @Test
+  public void generateAlterTable_changeInterleaveParentAndEnforcementRejected() {
+    getDiffCheckDdlDiffException(
+        "create table test1 (col1 int64, col2 int64) "
+            + "primary key (col1), interleave in parent testparent;",
+        "create table test1 (col1 int64, col2 int64) "
+            + "primary key (col1), interleave in otherparent;",
+        true,
+        "Cannot change interleaved parent of table test1");
   }
 
   @Test

--- a/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
@@ -20,6 +20,7 @@ import static com.google.cloud.solutions.spannerddl.diff.DdlDiff.ALLOW_DROP_STAT
 import static com.google.cloud.solutions.spannerddl.diff.DdlDiff.ALLOW_RECREATE_CONSTRAINTS_OPT;
 import static com.google.cloud.solutions.spannerddl.diff.DdlDiff.ALLOW_RECREATE_INDEXES_OPT;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.solutions.spannerddl.parser.ASTddl_statement;
@@ -360,6 +361,45 @@ public class DdlDiffTest {
                     + "primary key (col1), interleave in parent testparent on delete cascade",
                 true))
         .containsExactly("ALTER TABLE test1 SET ON DELETE CASCADE");
+  }
+
+  @Test
+  public void generateDifferences_nonParentInterleaveDoesNotAddOnDelete() throws DdlDiffException {
+    String parentTable = "create table parent_table (col1 int64) primary key (col1);";
+    String colocatedTable =
+        "create table colocated (col1 int64) primary key (col1), interleave in parent_table;";
+
+    assertThat(getDiff(parentTable, parentTable + colocatedTable, false))
+        .containsExactly(
+            "CREATE TABLE colocated ( col1 INT64 ) PRIMARY KEY (col1),"
+                + " INTERLEAVE IN parent_table");
+  }
+
+  @Test
+  public void generateAlterTable_nonParentInterleaveCanAddColumn() throws DdlDiffException {
+    assertThat(
+            getDiff(
+                "create table test1 (col1 int64) primary key (col1),"
+                    + " interleave in parent_table;",
+                "create table test1 (col1 int64, col2 int64) primary key (col1),"
+                    + " interleave in parent_table;",
+                false))
+        .containsExactly("ALTER TABLE test1 ADD COLUMN col2 INT64");
+  }
+
+  @Test
+  public void parseNonParentInterleaveRejectsOnDelete() {
+    IllegalArgumentException error =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DdlDiff.parseDdl(
+                    "create table test (col1 int64) primary key (col1),"
+                        + " interleave in other_table on delete no action"));
+
+    assertThat(error)
+        .hasMessageThat()
+        .isEqualTo("ON DELETE is only valid for INTERLEAVE IN PARENT clauses");
   }
 
   @Test

--- a/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLParserTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/parser/DDLParserTest.java
@@ -123,6 +123,20 @@ public class DDLParserTest {
   }
 
   @Test
+  public void parseNonParentInterleaveDoesNotAddOnDelete() throws ParseException {
+    ASTcreate_table_statement statement =
+        (ASTcreate_table_statement)
+            parse(
+                    "create table test (col1 int64) primary key (col1),"
+                        + " interleave in other_table")
+                .jjtGetChild(0);
+
+    assertThat(statement.toString())
+        .isEqualTo(
+            "CREATE TABLE test ( col1 INT64 ) PRIMARY KEY (col1)," + " INTERLEAVE IN other_table");
+  }
+
+  @Test
   public void parseDDLCreateIndexSyntaxError() {
     parseCheckingParseException(
         "Create index index1 on test1", "Was expecting one of:\n\n\"(\" ...");

--- a/src/test/resources/ddlParserValidation.txt
+++ b/src/test/resources/ddlParserValidation.txt
@@ -202,7 +202,7 @@ CREATE TABLE test1 (
 CREATE TABLE test1 (
   keycol INT64,
   value INT64
-) PRIMARY KEY (keycol ASC), INTERLEAVE IN other_table ON DELETE NO ACTION
+) PRIMARY KEY (keycol ASC), INTERLEAVE IN other_table
 
 == Test 21 create index with OPTIONS
 


### PR DESCRIPTION
Fix this tool's handling of `INTERLEAVE IN` clauses in multiple ways. It now supports adding/removing the `PARENT` keyword and changing the `ON DELETE` clause.