### PR TITLE
fix: treat optional identifier quoting as equivalent in table diffs

### DIFF
--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/AstTreeUtils.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/AstTreeUtils.java
@@ -111,6 +111,16 @@ public class AstTreeUtils {
         .collect(Collectors.toList());
   }
 
+  /** Returns the name represented by either a quoted or unquoted identifier token. */
+  public static String unquoteIdentifier(String identifier) {
+    if (identifier.length() >= 2
+        && identifier.charAt(0) == '`'
+        && identifier.charAt(identifier.length() - 1) == '`') {
+      return identifier.substring(1, identifier.length() - 1);
+    }
+    return identifier;
+  }
+
   private AstTreeUtils() {}
 
   /**

--- a/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/diff/DdlDiff.java
@@ -506,7 +506,7 @@ public class DdlDiff {
     }
 
     // Check Key is same
-    if (!left.getPrimaryKey().toString().equals(right.getPrimaryKey().toString())) {
+    if (!left.getPrimaryKey().hasSameColumns(right.getPrimaryKey())) {
       throw new DdlDiffException("Cannot change primary key of table " + left.getTableName());
     }
 

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcolumn_def.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcolumn_def.java
@@ -105,16 +105,21 @@ public class ASTcolumn_def extends SimpleNode {
             ASToptions_clause.class));
   }
 
+  private String comparableDefinition() {
+    String name = getColumnName();
+    return AstTreeUtils.unquoteIdentifier(name) + toString().substring(name.length());
+  }
+
   @Override
   public boolean equals(Object other) {
     if (other instanceof ASTcolumn_def) {
-      return this.toString().equals(other.toString());
+      return this.comparableDefinition().equals(((ASTcolumn_def) other).comparableDefinition());
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return toString().hashCode();
+    return comparableDefinition().hashCode();
   }
 }

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTcreate_table_statement.java
@@ -52,7 +52,7 @@ public class ASTcreate_table_statement extends SimpleNode {
     for (Node child : children) {
       if (child instanceof ASTcolumn_def) {
         ASTcolumn_def column = (ASTcolumn_def) child;
-        columns.put(column.getColumnName(), column);
+        columns.put(AstTreeUtils.unquoteIdentifier(column.getColumnName()), column);
       }
     }
     return columns;

--- a/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTprimary_key.java
+++ b/src/main/java/com/google/cloud/solutions/spannerddl/parser/ASTprimary_key.java
@@ -31,6 +31,29 @@ public class ASTprimary_key extends SimpleNode {
     super(p, id);
   }
 
+  /** Compares key columns without treating optional identifier quoting as a key change. */
+  public boolean hasSameColumns(ASTprimary_key other) {
+    List<ASTkey_part> keyparts = AstTreeUtils.getChildrenAssertType(children, ASTkey_part.class);
+    List<ASTkey_part> otherKeyparts =
+        AstTreeUtils.getChildrenAssertType(other.children, ASTkey_part.class);
+    if (keyparts.size() != otherKeyparts.size()) {
+      return false;
+    }
+    for (int i = 0; i < keyparts.size(); i++) {
+      ASTkey_part keypart = keyparts.get(i);
+      ASTkey_part otherKeypart = otherKeyparts.get(i);
+      if (!AstTreeUtils.unquoteIdentifier(keypart.getKeyPath())
+              .equals(AstTreeUtils.unquoteIdentifier(otherKeypart.getKeyPath()))
+          || !keypart
+              .toString()
+              .substring(keypart.getKeyPath().length())
+              .equals(otherKeypart.toString().substring(otherKeypart.getKeyPath().length()))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   @Override
   public String toString() {
     List<ASTkey_part> keyparts = AstTreeUtils.getChildrenAssertType(children, ASTkey_part.class);

--- a/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
+++ b/src/test/java/com/google/cloud/solutions/spannerddl/diff/DdlDiffTest.java
@@ -284,6 +284,26 @@ public class DdlDiffTest {
   }
 
   @Test
+  public void generateAlterTable_equivalentQuotedIdentifiers() throws DdlDiffException {
+    String unquoted =
+        "CREATE TABLE test1 (index INT64 NOT NULL, col2 STRING(1024))"
+            + " PRIMARY KEY (index);";
+    String quoted =
+        "CREATE TABLE test1 (`index` INT64 NOT NULL, `col2` STRING(1024))"
+            + " PRIMARY KEY (`index`);";
+
+    assertThat(getDiff(unquoted, quoted, true)).isEmpty();
+    assertThat(getDiff(quoted, unquoted, true)).isEmpty();
+    assertThat(
+            getDiff(
+                unquoted,
+                "CREATE TABLE test1 (`index` INT64 NOT NULL, `col2` STRING(2048))"
+                    + " PRIMARY KEY (`index`);",
+                true))
+        .containsExactly("ALTER TABLE test1 ALTER COLUMN `col2` STRING(2048)");
+  }
+
+  @Test
   public void generateAlterTable_changeKey() {
     // change key col
     getDiffCheckDdlDiffException(


### PR DESCRIPTION
Cloud Spanner's live DDL may omit optional backticks present in a source schema. The first schema update can succeed, but subsequent plans then fail with “Cannot change primary key” because the diff compares rendered key text. Quoted and unquoted column names can likewise appear to be different columns.

Compare primary-key parts and column definitions by their identifier values rather than optional quoting, while retaining the source spelling in generated DDL. Key order and direction remain significant, and genuine column changes still produce migrations.
